### PR TITLE
DT-2845: update create and update roles in nomis to call nomis before calling auth…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/RolesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/RolesService.kt
@@ -12,19 +12,19 @@ import uk.gov.justice.digital.hmpps.manageusersapi.service.AdminType.DPS_LSA
 
 @Service
 class RolesService(
-  val authService: AuthService,
   val nomisApiService: NomisApiService,
+  val authService: AuthService,
 ) {
 
   @Throws(RoleExistsException::class)
   fun createRole(createRole: CreateRole) {
-    // call to hmpps-auth to create the role
-    // hmpps-auth called first as it will hold a duplicate copy of the roles in nomis so that we can add a role description
-    authService.createRole(createRole)
     // call to Nomis-api to create the new role
     if (createRole.adminType.hasDPSAdminType()) {
       nomisApiService.createRole(createRole)
     }
+    // call to hmpps-auth to create the role
+    // hmpps-auth called first as it will hold a duplicate copy of the roles in nomis so that we can add a role description
+    authService.createRole(createRole)
   }
 
   fun getRoles(
@@ -47,10 +47,10 @@ class RolesService(
   @Throws(RoleNotFoundException::class)
   fun updateRoleName(roleCode: String, roleAmendment: RoleNameAmendment) {
     val originalRole = getRoleDetail(roleCode)
-    authService.updateRoleName(roleCode, roleAmendment)
     if (originalRole.isDPSRole()) {
       nomisApiService.updateRoleName(roleCode, roleAmendment)
     }
+    authService.updateRoleName(roleCode, roleAmendment)
   }
 
   @Throws(RoleNotFoundException::class)
@@ -60,8 +60,6 @@ class RolesService(
   @Throws(RoleNotFoundException::class)
   fun updateRoleAdminType(roleCode: String, roleAmendment: RoleAdminTypeAmendment) {
     val originalRole = authService.getRoleDetail(roleCode)
-    authService.updateRoleAdminType(roleCode, roleAmendment)
-
     if (originalRole.isDpsRoleAdminTypeChanging(roleAmendment.adminType)) {
       nomisApiService.updateRoleAdminType(roleCode, roleAmendment)
     } else if (!originalRole.isDPSRole() && roleAmendment.adminType.hasDPSAdminType()) {
@@ -74,6 +72,8 @@ class RolesService(
         )
       )
     }
+
+    authService.updateRoleAdminType(roleCode, roleAmendment)
   }
 
   private fun Role.isDPSRole(): Boolean = adminType.asAdminTypes().hasDPSAdminType()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/integration/wiremock/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/integration/wiremock/NomisApiMockServer.kt
@@ -38,6 +38,17 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
+  fun stubCreateRoleFail(status: HttpStatus) {
+    stubFor(
+      post(urlEqualTo("/roles"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(status.value())
+        )
+    )
+  }
+
   fun stubPutRole(roleCode: String) {
     stubFor(
       put("/roles/$roleCode")
@@ -45,6 +56,17 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
           aResponse()
             .withStatus(HttpStatus.OK.value())
             .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+        )
+    )
+  }
+
+  fun stubPutRoleFail(roleCode: String, status: HttpStatus) {
+    stubFor(
+      put("/roles/$roleCode")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(status.value())
         )
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/RolesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/RolesServiceTest.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.manageusersapi.service.AdminType.EXT_ADM
 class RolesServiceTest {
   private val authService: AuthService = mock()
   private val nomisService: NomisApiService = mock()
-  private val rolesService = RolesService(authService, nomisService)
+  private val rolesService = RolesService(nomisService, authService)
 
   @Nested
   inner class GetAllRoles {


### PR DESCRIPTION
… so that if nomis call fails then auth is not called