### PR TITLE
HAAR-1257: linking general user to existing admin

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/adapter/nomis/UserApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/adapter/nomis/UserApiService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.manageusersapi.model.PrisonStaffUser
 import uk.gov.justice.digital.hmpps.manageusersapi.model.PrisonUser
 import uk.gov.justice.digital.hmpps.manageusersapi.model.PrisonUserSummary
 import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateLinkedCentralAdminUserRequest
+import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateLinkedGeneralUserRequest
 import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateLinkedLocalAdminUserRequest
 import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateUserRequest
 
@@ -109,6 +110,18 @@ class UserApiService(
       mapOf(
         "username" to localAdminUser.adminUsername,
         "localAdminGroup" to localAdminUser.localAdminGroup,
+      ),
+      PrisonStaffUser::class.java,
+    )
+  }
+
+  fun linkGeneralUser(generalUser: CreateLinkedGeneralUserRequest): PrisonStaffUser {
+    log.debug("Link DPS general user - {}", generalUser.generalUsername)
+    return userWebClientUtils.postWithResponse(
+      "/users/link-general-account/${generalUser.existingAdminUsername}",
+      mapOf(
+        "username" to generalUser.generalUsername,
+        "defaultCaseloadId" to generalUser.defaultCaseloadId,
       ),
       PrisonStaffUser::class.java,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/prison/UserController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/prison/UserController.kt
@@ -263,6 +263,63 @@ class UserController(
     createLinkedLocalAdminUserRequest: CreateLinkedLocalAdminUserRequest,
   ) = PrisonStaffUserDto.fromDomain(prisonUserService.createLinkedLocalAdminUser(createLinkedLocalAdminUserRequest))
 
+  @PostMapping("/linkedprisonusers/general", produces = [MediaType.APPLICATION_JSON_VALUE])
+  @PreAuthorize("hasRole('ROLE_CREATE_USER')")
+  @ResponseStatus(HttpStatus.CREATED)
+  @Operation(
+    summary = "Link a New General User to an existing Admin Account",
+    description = "Link a New General User to an existing Admin Account. Requires role ROLE_CREATE_USER",
+    security = [SecurityRequirement(name = "ROLE_CREATE_USER")],
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "General User linked to an existing Admin Account",
+        content = [
+          io.swagger.v3.oas.annotations.media.Content(
+            mediaType = "application/json",
+            schema = io.swagger.v3.oas.annotations.media.Schema(
+              implementation = PrisonStaffUserDto::class,
+            ),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incorrect request to link a general user to an admin user",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint, requires a valid OAuth2 token",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to link a general user to an existing admin user",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun createLinkedGeneralUser(
+    @RequestBody @Valid
+    createLinkedGeneralUserRequest: CreateLinkedGeneralUserRequest,
+  ) = PrisonStaffUserDto.fromDomain(prisonUserService.createLinkedGeneralUser(createLinkedGeneralUserRequest))
+
   @GetMapping("/prisonusers", produces = [MediaType.APPLICATION_JSON_VALUE])
   @PreAuthorize("hasAnyRole('ROLE_USE_OF_FORCE', 'ROLE_STAFF_SEARCH')")
   @Operation(
@@ -445,6 +502,37 @@ data class CreateLinkedLocalAdminUserRequest(
   )
   @NotBlank
   val localAdminGroup: String,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Linking a new General account to an existing admin user account")
+data class CreateLinkedGeneralUserRequest(
+  @Schema(description = "existing admin username", example = "TESTUSER1_ADM", required = true)
+  @field:Size(
+    max = 30,
+    min = 1,
+    message = "Admin Username must be between 1 and 30",
+  )
+  @NotBlank
+  val existingAdminUsername: String,
+
+  @Schema(description = "new general username", example = "TESTUSER1_GEN", required = true)
+  @field:Size(
+    max = 30,
+    min = 1,
+    message = "Username must be between 1 and 30",
+  )
+  @NotBlank
+  val generalUsername: String,
+
+  @Schema(description = "Default caseload (a.k.a Prison ID), not required for admin accounts", example = "BXI", required = true)
+  @field:Size(
+    max = 6,
+    min = 3,
+    message = "Caseload must be between 3-6 characters",
+  )
+  @NotBlank
+  val defaultCaseloadId: String,
 )
 
 data class AmendEmail(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/prison/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/prison/UserService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.manageusersapi.model.PrisonStaffUser
 import uk.gov.justice.digital.hmpps.manageusersapi.model.PrisonUser
 import uk.gov.justice.digital.hmpps.manageusersapi.model.PrisonUserSummary
 import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateLinkedCentralAdminUserRequest
+import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateLinkedGeneralUserRequest
 import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateLinkedLocalAdminUserRequest
 import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateUserRequest
 import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.UserType.DPS_ADM
@@ -53,13 +54,18 @@ class UserService(
   }
 
   @Throws(HmppsValidationException::class)
-  fun createLinkedCentralAdminUser(user: CreateLinkedCentralAdminUserRequest): PrisonStaffUser {
-    return prisonUserApiService.linkCentralAdminUser(user)
+  fun createLinkedCentralAdminUser(linkUserRequest: CreateLinkedCentralAdminUserRequest): PrisonStaffUser {
+    return prisonUserApiService.linkCentralAdminUser(linkUserRequest)
   }
 
   @Throws(HmppsValidationException::class)
-  fun createLinkedLocalAdminUser(user: CreateLinkedLocalAdminUserRequest): PrisonStaffUser {
-    return prisonUserApiService.linkLocalAdminUser(user)
+  fun createLinkedLocalAdminUser(linkUserRequest: CreateLinkedLocalAdminUserRequest): PrisonStaffUser {
+    return prisonUserApiService.linkLocalAdminUser(linkUserRequest)
+  }
+
+  @Throws(HmppsValidationException::class)
+  fun createLinkedGeneralUser(linkUserRequest: CreateLinkedGeneralUserRequest): PrisonStaffUser {
+    return prisonUserApiService.linkGeneralUser(linkUserRequest)
   }
 
   fun findUsersByFirstAndLastName(firstName: String, lastName: String): List<EnhancedPrisonUser> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/integration/wiremock/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/integration/wiremock/NomisApiMockServer.kt
@@ -11,6 +11,7 @@ import com.github.tomakehurst.wiremock.http.HttpHeader
 import com.github.tomakehurst.wiremock.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateLinkedCentralAdminUserRequest
+import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateLinkedGeneralUserRequest
 import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateLinkedLocalAdminUserRequest
 
 class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
@@ -184,6 +185,72 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
                     "primaryEmail": "f.l@justice.gov.uk",
                     "generalAccount": {
                         "username": "TESTUSER1",
+                        "active": false,
+                        "accountType": "GENERAL",
+                        "activeCaseload": {
+                            "id": "BXI",
+                            "name": "Brixton (HMP)"
+                        },
+                        "caseloads": [
+                            {
+                                "id": "NWEB",
+                                "name": "Nomis-web Application"
+                            },
+                            {
+                                "id": "BXI",
+                                "name": "Brixton (HMP)"
+                            }
+                        ]
+                    },
+                    "adminAccount": {
+                        "username": "TESTUSER1_ADM",
+                        "active": false,
+                        "accountType": "ADMIN",
+                        "activeCaseload": {
+                            "id": "CADM_I",
+                            "name": "Central Administration Caseload For Hmps"
+                        },
+                        "caseloads": [
+                            {
+                                "id": "NWEB",
+                                "name": "Nomis-web Application"
+                            },
+                            {
+                                "id": "CADM_I",
+                                "name": "Central Administration Caseload For Hmps"
+                            }
+                        ]
+                    }
+                }
+              """.trimIndent(),
+            ),
+        ),
+    )
+  }
+
+  fun stubCreateLinkedGeneralUser(request: CreateLinkedGeneralUserRequest) {
+    stubFor(
+      post(urlEqualTo("/users/link-general-account/${request.existingAdminUsername}")).withRequestBody(
+        WireMock.containing(
+          """
+          {"username":"TESTUSER1_GEN","defaultCaseloadId":"BXI"}
+          """.trimIndent(),
+        ),
+      )
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(201)
+            .withBody(
+              """
+                {
+                    "staffId": 100,
+                    "firstName": "First",
+                    "lastName": "Last",
+                    "status": "ACTIVE",
+                    "primaryEmail": "f.l@justice.gov.uk",
+                    "generalAccount": {
+                        "username": "TESTUSER1_GEN",
                         "active": false,
                         "accountType": "GENERAL",
                         "activeCaseload": {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/prison/UserControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/prison/UserControllerIntTest.kt
@@ -863,7 +863,7 @@ class UserControllerIntTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `create linked local admin user call passes through error when error thrown from nomisapi`() {
+    fun `create linked local admin user call passes through error when bad request error thrown from nomisapi`() {
       nomisApiMockServer.stubSpecifiedHttpStatusOnPostTo("/users/link-local-admin-account/TEST_USER", BAD_REQUEST)
       webTestClient.post().uri("/linkedprisonusers/lsa")
         .headers(setAuthorisation(roles = listOf("ROLE_CREATE_USER")))
@@ -873,6 +873,186 @@ class UserControllerIntTest : IntegrationTestBase() {
               "existingUsername" to "TEST_USER",
               "adminUsername" to "TEST_USER_ADM",
               "localAdminGroup" to "MDI",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isEqualTo(BAD_REQUEST)
+        .expectBody()
+        .jsonPath("status").isEqualTo(BAD_REQUEST.value())
+        .jsonPath("$.userMessage").isEqualTo("User test message")
+        .jsonPath("$.developerMessage").isEqualTo("Developer test message")
+    }
+  }
+
+  @Nested
+  inner class CreateLinkedGeneralUser {
+    @Test
+    fun `access forbidden when no authority`() {
+      webTestClient.post().uri("/linkedprisonusers/general")
+        .body(
+          fromValue(
+            mapOf(
+              "existingAdminUsername" to "TESTUSER1_ADM",
+              "generalUsername" to "TESTUSER1_GEN",
+              "defaultCaseloadId" to "BXI",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `access forbidden when no role`() {
+      webTestClient.post().uri("/linkedprisonusers/general")
+        .headers(setAuthorisation(roles = listOf()))
+        .body(
+          fromValue(
+            mapOf(
+              "existingAdminUsername" to "TESTUSER1_ADM",
+              "generalUsername" to "TESTUSER1_GEN",
+              "defaultCaseloadId" to "BXI",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `access forbidden when wrong role`() {
+      webTestClient.post().uri("/linkedprisonusers/general")
+        .headers(setAuthorisation(roles = listOf("ROLE_WRONG_ROLE")))
+        .body(
+          fromValue(
+            mapOf(
+              "existingAdminUsername" to "TESTUSER1_ADM",
+              "generalUsername" to "TESTUSER1_GEN",
+              "defaultCaseloadId" to "BXI",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `access forbidden when wrong scope`() {
+      webTestClient.post().uri("/linkedprisonusers/general")
+        .headers(setAuthorisation(roles = listOf("ROLE_CREATE_ROLE"), scopes = listOf("read")))
+        .body(
+          fromValue(
+            mapOf(
+              "existingAdminUsername" to "TESTUSER1_ADM",
+              "generalUsername" to "TESTUSER1_GEN",
+              "defaultCaseloadId" to "BXI",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `Link a General user to an existing Admin User`() {
+      val createLinkedGeneralRequest = CreateLinkedGeneralUserRequest("TESTUSER1_ADM", "TESTUSER1_GEN", "BXI")
+
+      nomisApiMockServer.stubCreateLinkedGeneralUser(createLinkedGeneralRequest)
+
+      val prisonStaffUser = webTestClient.post().uri("/linkedprisonusers/general")
+        .headers(setAuthorisation(roles = listOf("ROLE_CREATE_USER")))
+        .body(
+          fromValue(
+            mapOf(
+              "existingAdminUsername" to "TESTUSER1_ADM",
+              "generalUsername" to "TESTUSER1_GEN",
+              "defaultCaseloadId" to "BXI",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isCreated
+        .expectBody(PrisonStaffUserDto::class.java)
+        .returnResult().responseBody!!
+
+      assertThat(prisonStaffUser.staffId).isEqualTo(100L)
+      assertThat(prisonStaffUser.firstName).isEqualTo("First")
+      assertThat(prisonStaffUser.lastName).isEqualTo("Last")
+      assertThat(prisonStaffUser.status).isEqualTo("ACTIVE")
+      assertThat(prisonStaffUser.primaryEmail).isEqualTo("f.l@justice.gov.uk")
+      assertThat(prisonStaffUser.generalAccount?.accountType).isEqualTo(PrisonUsageType.GENERAL)
+      assertThat(prisonStaffUser.adminAccount?.accountType).isEqualTo(PrisonUsageType.ADMIN)
+
+      nomisApiMockServer.verify(
+        postRequestedFor(urlEqualTo("/users/link-general-account/${createLinkedGeneralRequest.existingAdminUsername}"))
+          .withRequestBody(
+            containing(
+              """
+              {"username":"${createLinkedGeneralRequest.generalUsername}","defaultCaseloadId":"${createLinkedGeneralRequest.defaultCaseloadId}"}
+              """.trimIndent(),
+            ),
+          ),
+      )
+    }
+
+    @Test
+    fun `create linked general user returns error when the general user already exists`() {
+      nomisApiMockServer.stubConflictOnPostTo("/users/link-general-account/TESTUSER1_ADM")
+      webTestClient.post().uri("/linkedprisonusers/general")
+        .headers(setAuthorisation(roles = listOf("ROLE_CREATE_USER")))
+        .body(
+          fromValue(
+            mapOf(
+              "existingAdminUsername" to "TESTUSER1_ADM",
+              "generalUsername" to "TESTUSER1_GEN",
+              "defaultCaseloadId" to "BXI",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isEqualTo(CONFLICT)
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .jsonPath("status").isEqualTo(CONFLICT.value())
+        .jsonPath("$.userMessage").isEqualTo("User test message")
+        .jsonPath("$.developerMessage").isEqualTo("Developer test message")
+    }
+
+    @Test
+    fun `create linked general user returns error when specified admin user is not found`() {
+      nomisApiMockServer.stubNotFoundOnPostTo("/users/link-general-account/TESTUSER_ADM_NOT_FOUND")
+      webTestClient.post().uri("/linkedprisonusers/general")
+        .headers(setAuthorisation(roles = listOf("ROLE_CREATE_USER")))
+        .body(
+          fromValue(
+            mapOf(
+              "existingAdminUsername" to "TESTUSER_ADM_NOT_FOUND",
+              "generalUsername" to "TESTUSER_GEN",
+              "defaultCaseloadId" to "BXI",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isEqualTo(NOT_FOUND)
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .jsonPath("status").isEqualTo(NOT_FOUND.value())
+        .jsonPath("$.userMessage").isEqualTo("User test message")
+        .jsonPath("$.developerMessage").isEqualTo("Developer test message")
+    }
+
+    @Test
+    fun `create linked general user call passes through error when bad request error is thrown from nomisapi`() {
+      nomisApiMockServer.stubSpecifiedHttpStatusOnPostTo("/users/link-general-account/TESTUSER1_ADM", BAD_REQUEST)
+      webTestClient.post().uri("/linkedprisonusers/general")
+        .headers(setAuthorisation(roles = listOf("ROLE_CREATE_USER")))
+        .body(
+          fromValue(
+            mapOf(
+              "existingAdminUsername" to "TESTUSER1_ADM",
+              "generalUsername" to "TESTUSER1_GEN",
+              "defaultCaseloadId" to "BXI",
             ),
           ),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/prison/UserControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/prison/UserControllerTest.kt
@@ -118,6 +118,45 @@ class UserControllerTest {
   }
 
   @Nested
+  inner class CreateLinkedGeneralUser {
+    @Test
+    fun `create Linked General user`() {
+      val generalCaseLoads = listOf(
+        PrisonCaseload("NWEB", "Nomis-web Application"),
+        PrisonCaseload("BXI", "Brixton (HMP)"),
+      )
+      val adminCaseLoads = listOf(
+        PrisonCaseload("NWEB", "Nomis-web Application"),
+        PrisonCaseload("CADM_I", "Central Administration Caseload For Hmps"),
+      )
+
+      val generalAccount = UserCaseload(
+        "TEST_USER_GEN",
+        false,
+        PrisonUsageType.GENERAL,
+        generalCaseLoads.get(1),
+        generalCaseLoads,
+      )
+      val adminAccount =
+        UserCaseload("TEST_USER_ADM", false, PrisonUsageType.ADMIN, adminCaseLoads.get(1), adminCaseLoads)
+      val createLinkedGeneralUserRequest = CreateLinkedGeneralUserRequest("TEST_USER_ADM", "TEST_USER_GEN", "BXI")
+      whenever(userService.createLinkedGeneralUser(createLinkedGeneralUserRequest)).thenReturn(
+        PrisonStaffUser(
+          100,
+          "First",
+          "Last",
+          "ACTIVE",
+          "f.l@justice.gov.uk",
+          generalAccount,
+          adminAccount,
+        ),
+      )
+      userController.createLinkedGeneralUser(createLinkedGeneralUserRequest)
+      verify(userService).createLinkedGeneralUser(createLinkedGeneralUserRequest)
+    }
+  }
+
+  @Nested
   inner class FindUsersByFirstAndLastName {
     @Test
     fun `no matches`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/prison/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/prison/UserServiceTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.manageusersapi.model.PrisonUser
 import uk.gov.justice.digital.hmpps.manageusersapi.model.PrisonUserSummary
 import uk.gov.justice.digital.hmpps.manageusersapi.model.UserCaseload
 import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateLinkedCentralAdminUserRequest
+import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateLinkedGeneralUserRequest
 import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateLinkedLocalAdminUserRequest
 import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.CreateUserRequest
 import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.UserType.DPS_ADM
@@ -206,7 +207,7 @@ class UserServiceTest {
   }
 
   @Nested
-  inner class CreateLinkedCentralAdminAccount {
+  inner class CreateLinkedCentralAdminAccountToAnExistingGeneralAccount {
     @Test
     fun `create a DPS central admin user linked to a General account`() {
       val createLinkedCentralAdminUserRequest = CreateLinkedCentralAdminUserRequest("TEST_USER", "TEST_USER_ADM")
@@ -247,7 +248,7 @@ class UserServiceTest {
   }
 
   @Nested
-  inner class CreateLinkedLocalAdminAccount {
+  inner class CreateLinkedLocalAdminAccountToAnExistingGeneralAccount {
     @Test
     fun `create a DPS Local admin user linked to a General account`() {
       val createLinkedLocalAdminUserRequest = CreateLinkedLocalAdminUserRequest("TEST_USER", "TEST_USER_ADM", "MDI")
@@ -284,6 +285,47 @@ class UserServiceTest {
       prisonUserService.createLinkedLocalAdminUser(createLinkedLocalAdminUserRequest)
 
       verify(prisonUserApiService).linkLocalAdminUser(createLinkedLocalAdminUserRequest)
+    }
+  }
+
+  @Nested
+  inner class CreateLinkedGeneralAccountToAnExistingAdminAccount {
+    @Test
+    fun `create a DPS General user linked to an Admin account`() {
+      val createLinkedGeneralUserRequest = CreateLinkedGeneralUserRequest("TEST_USER_ADM", "TEST_USER_GEN", "BXI")
+      val generalCaseLoads = listOf(
+        PrisonCaseload("NWEB", "Nomis-web Application"),
+        PrisonCaseload("BXI", "Brixton (HMP)"),
+      )
+      val adminCaseLoads = listOf(
+        PrisonCaseload("NWEB", "Nomis-web Application"),
+        PrisonCaseload("CADM_I", "Central Administration Caseload For Hmps"),
+      )
+      val generalAccount = UserCaseload(
+        "TEST_USER_GEN",
+        false,
+        PrisonUsageType.GENERAL,
+        generalCaseLoads.get(1),
+        generalCaseLoads,
+      )
+      val adminAccount =
+        UserCaseload("TEST_USER_ADM", false, PrisonUsageType.ADMIN, adminCaseLoads.get(1), adminCaseLoads)
+
+      whenever(prisonUserApiService.linkGeneralUser(createLinkedGeneralUserRequest)).thenReturn(
+        PrisonStaffUser(
+          100,
+          "First",
+          "Last",
+          "ACTIVE",
+          "f.l@justice.gov.uk",
+          generalAccount,
+          adminAccount,
+        ),
+      )
+
+      prisonUserService.createLinkedGeneralUser(createLinkedGeneralUserRequest)
+
+      verify(prisonUserApiService).linkGeneralUser(createLinkedGeneralUserRequest)
     }
   }
 


### PR DESCRIPTION
Pass through api endpoint linking a new general user to an existing admin account, with the target endpoint in nomis-user-roles-api.