### PR TITLE
PI-1493 Switch from Community API to Probation Integration service

### DIFF
--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -16,7 +16,7 @@ services:
     container_name: hmpps-auth
     depends_on:
       - auth-db
-      - community-api
+      - delius
     ports:
       - '9090:8080'
     healthcheck:
@@ -24,14 +24,14 @@ services:
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev,delius,local-postgres
-      - DELIUS_ENDPOINT_URL=http://community-api:8080
+      - DELIUS_ENDPOINT_URL=http://delius:8080
       - MANAGE_USERS_API_ENDPOINT_URL=http://hmpps-manage-users-api:9091
       - SPRING_DATASOURCE_URL=jdbc:postgresql://auth-db:5432/auth-db
       - HOSTNAME=hmpps-auth
 
-  community-api:
-    image: quay.io/hmpps/community-api:latest
-    container_name: community-api
+  delius:
+    image: ghcr.io/ministryofjustice/hmpps-probation-integration-services/hmpps-auth-and-delius:latest
+    container_name: delius
     ports:
       - '8091:8080'
     healthcheck:
@@ -61,7 +61,7 @@ services:
     container_name: hmpps-manage-users-api
     depends_on:
       - hmpps-external-users-api
-      - community-api
+      - delius
       - nomis-user-roles-api
     ports:
       - "9091:8080"
@@ -73,7 +73,7 @@ services:
       - HMPPS-AUTH_ENDPOINT_URL=http://hmpps-auth:8080/auth
       - EXTERNAL-USERS_ENDPOINT_URL=http://hmpps-external-users-api:8080
       - NOMIS_ENDPOINT_URL=http://nomis-user-roles-api:8080
-      - DELIUS_ENDPOINT_URL=http://community-api:8080
+      - DELIUS_ENDPOINT_URL=http://delius:8080
 
   nomis-user-roles-api:
     image: quay.io/hmpps/nomis-user-roles-api:latest

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,7 +14,7 @@ generic-service:
     HMPPS_AUTH_EXTERNAL_ENDPOINT_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     NOMIS_ENDPOINT_URL: https://nomis-user-roles-api-dev.prison.service.justice.gov.uk
     EXTERNAL_USERS_ENDPOINT_URL: https://external-users-api-dev.hmpps.service.justice.gov.uk
-    DELIUS_ENDPOINT_URL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
+    DELIUS_ENDPOINT_URL: https://hmpps-auth-and-delius-dev.hmpps.service.justice.gov.uk
     BANNER_ROLES:
     BANNER_EMPTY:
     BANNER_DPSMENU:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,7 +14,7 @@ generic-service:
     HMPPS_AUTH_EXTERNAL_ENDPOINT_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     NOMIS_ENDPOINT_URL: https://nomis-user-pp.aks-live-1.studio-hosting.service.justice.gov.uk
     EXTERNAL_USERS_ENDPOINT_URL: https://external-users-api-preprod.hmpps.service.justice.gov.uk
-    DELIUS_ENDPOINT_URL: https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io
+    DELIUS_ENDPOINT_URL: https://hmpps-auth-and-delius-preprod.hmpps.service.justice.gov.uk
     BANNER_ROLES:
     BANNER_EMPTY:
     BANNER_DPSMENU:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -13,7 +13,7 @@ generic-service:
     HMPPS_AUTH_EXTERNAL_ENDPOINT_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
     NOMIS_ENDPOINT_URL: https://nomis-user.aks-live-1.studio-hosting.service.justice.gov.uk
     EXTERNAL_USERS_ENDPOINT_URL: https://external-users-api.hmpps.service.justice.gov.uk
-    DELIUS_ENDPOINT_URL: https://community-api-secure.probation.service.justice.gov.uk
+    DELIUS_ENDPOINT_URL: https://hmpps-auth-and-delius.hmpps.service.justice.gov.uk
     BANNER_ROLES:
     BANNER_EMPTY:
     BANNER_DPSMENU:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/config/DeliusWebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/config/DeliusWebClientConfiguration.kt
@@ -22,8 +22,7 @@ class DeliusWebClientConfiguration(appContext: ApplicationContext) :
   fun getDeliusClientRegistration(): ClientRegistration = getClientRegistration()
 
   @Bean
-  fun deliusWebClient(builder: Builder, authorizedClientManager: OAuth2AuthorizedClientManager): WebClient =
-    getWebClient(builder, authorizedClientManager, "/secure")
+  fun deliusWebClient(builder: Builder, authorizedClientManager: OAuth2AuthorizedClientManager) = getWebClient(builder, authorizedClientManager)
 
   @Bean
   fun deliusHealthWebClient(builder: Builder): WebClient = getHealthWebClient(builder)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/model/DeliusUser.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/model/DeliusUser.kt
@@ -11,7 +11,7 @@ data class DeliusUser(
   val surname: String,
   val enabled: Boolean = false,
   val email: String,
-  val roles: List<UserRole>? = emptyList(),
+  val roles: List<String> = emptyList(),
 ) : SourceUser {
 
   val name: String
@@ -28,7 +28,7 @@ data class DeliusUser(
       name = name,
       userId = userId,
       uuid = null,
-      roles = roles,
+      roles = roles.map { UserRole(it) },
     )
 
   override fun emailAddress(): EmailAddress =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/UserService.kt
@@ -66,7 +66,7 @@ class UserService(
     return externalRolesApiService.findRolesByUsernameOrNull(username)?.map { UserRole(it.roleCode) }
       ?: run { prisonApiService.findUserByUsername(username)?.roles?.map { UserRole(it) } }
       ?: run { authApiService.findAzureUserByUsername(username)?.roles?.map { UserRole(it.name) } }
-      ?: run { deliusApiService.findUserByUsername(username)?.roles?.map { UserRole(it.name.substring(5)) } } // remove ROLE_
+      ?: run { deliusApiService.findUserByUsername(username)?.roles?.map { UserRole(it.substring(5)) } } // remove ROLE_
   }
 
   fun getAllDeliusRoles() = deliusApiService.getAllDeliusRoles()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/integration/wiremock/DeliusApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/integration/wiremock/DeliusApiMockServer.kt
@@ -26,7 +26,7 @@ class DeliusApiMockServer : WireMockServer(WIREMOCK_PORT) {
 
   fun stubGetUser(username: String) {
     stubFor(
-      get("/secure/users/$username/details")
+      get("/user/$username")
         .willReturn(
           aResponse()
             .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
@@ -37,17 +37,7 @@ class DeliusApiMockServer : WireMockServer(WIREMOCK_PORT) {
                 "surname": "Smith",
                 "email": "delius.smithy@digital.justice.gov.uk",
                 "enabled": true,
-                "roles": [
-                    {
-                        "name": "APBT001"
-                    },
-                    {
-                        "name": "APBT002"
-                    },
-                    {
-                        "name": "SPGADBT005"
-                    }
-                ],
+                "roles": ["APBT001", "APBT002", "SPGADBT005"],
                 "username": "$username"
               }
               """.trimIndent(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/UserControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/UserControllerIntTest.kt
@@ -29,7 +29,7 @@ class UserControllerIntTest : IntegrationTestBase() {
     if (external) externalUsersApiMockServer.stubGetFail("/users/$username", NOT_FOUND)
     if (nomis) nomisApiMockServer.stubGetFail("/users/${username.uppercase()}", NOT_FOUND)
     if (azure) hmppsAuthMockServer.stubGetFail("/auth/api/azureuser/$username", NOT_FOUND)
-    if (delius) deliusApiMockServer.stubGetFail("/secure/users/$username/details", NOT_FOUND)
+    if (delius) deliusApiMockServer.stubGetFail("/user/$username", NOT_FOUND)
   }
 
   @Nested
@@ -90,7 +90,7 @@ class UserControllerIntTest : IntegrationTestBase() {
         .expectStatus().isNotFound
       nomisApiMockServer.verify(0, getRequestedFor(urlEqualTo("/users/$username")))
       hmppsAuthMockServer.verify(0, getRequestedFor(urlEqualTo("/auth/api/azureuser/$username")))
-      deliusApiMockServer.verify(0, getRequestedFor(urlEqualTo("/secure/users/$username/details")))
+      deliusApiMockServer.verify(0, getRequestedFor(urlEqualTo("/user/$username")))
     }
 
     @Test
@@ -658,7 +658,7 @@ class UserControllerIntTest : IntegrationTestBase() {
       val username = "AUTH_ADM"
       externalUsersApiMockServer.stubGetFail("/users/username/$username/roles", NOT_FOUND)
       nomisApiMockServer.stubGetFail("/users/$username", NOT_FOUND)
-      deliusApiMockServer.stubGetFail("/secure/users/$username/details", NOT_FOUND)
+      deliusApiMockServer.stubGetFail("/user/$username", NOT_FOUND)
       webTestClient.get().uri("/users/$username/roles")
         .headers(setAuthorisation(roles = listOf("ROLE_PCMS_USER_ADMIN")))
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/UserServiceTest.kt
@@ -309,7 +309,7 @@ class UserServiceTest {
       surname = "Smith",
       enabled = true,
       email = "delius.smith@digital.justice.gov.uk",
-      roles = listOf(uk.gov.justice.digital.hmpps.manageusersapi.model.UserRole(name = "ROLE_TEST_ROLE")),
+      roles = listOf("ROLE_TEST_ROLE"),
     )
 
   fun createExternalUser() = ExternalUser(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/delius/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/delius/UserServiceTest.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.manageusersapi.adapter.WebClientUtils
 import uk.gov.justice.digital.hmpps.manageusersapi.adapter.delius.UserApiService
 import uk.gov.justice.digital.hmpps.manageusersapi.config.DeliusRoleMappings
 import uk.gov.justice.digital.hmpps.manageusersapi.model.DeliusUser
-import uk.gov.justice.digital.hmpps.manageusersapi.model.UserRole
 
 class UserServiceTest {
 
@@ -44,7 +43,7 @@ class UserServiceTest {
           surname = "Smith",
           email = "TEST@DIGITAL.JUSTICE.GOV.UK",
           enabled = true,
-          roles = listOf(UserRole("NO_ROLES")),
+          roles = listOf("NO_ROLES"),
         ),
       )
       val optionalDetails = deliusService.findUserByUsername("NO_ROLES")
@@ -72,7 +71,7 @@ class UserServiceTest {
           surname = "Smith",
           email = "TEST@DIGITAL.JUSTICE.GOV.UK",
           enabled = true,
-          roles = listOf(UserRole("TEST_ROLE")),
+          roles = listOf("TEST_ROLE"),
         ),
       )
       val optionalDetails = deliusService.findUserByUsername("DeliusSmith")
@@ -84,7 +83,7 @@ class UserServiceTest {
           surname = "Smith",
           email = "test@digital.justice.gov.uk",
           enabled = true,
-          roles = listOf(UserRole("role1"), UserRole("role3")),
+          roles = listOf("role1", "role3"),
         ),
       )
     }
@@ -99,7 +98,7 @@ class UserServiceTest {
           surname = "Smith",
           email = "TEST@DIGITAL.JUSTICE.GOV.UK",
           enabled = true,
-          roles = listOf(UserRole("AROLE")),
+          roles = listOf("AROLE"),
         ),
       )
       val optionalDetails = deliusService.findUserByUsername("deliussmith")
@@ -111,7 +110,7 @@ class UserServiceTest {
           surname = "Smith",
           email = "test@digital.justice.gov.uk",
           enabled = true,
-          roles = listOf(UserRole("role1"), UserRole("role2")),
+          roles = listOf("role1", "role2"),
         ),
       )
     }
@@ -126,7 +125,7 @@ class UserServiceTest {
           surname = "Smith",
           email = "TEST@DIGITAL.JUSTICE.GOV.UK",
           enabled = true,
-          roles = listOf(UserRole("NO_ROLES")),
+          roles = listOf("NO_ROLES"),
         ),
       )
       val optionalDetails = deliusService.findUserByUsername("DELIUS_MIXED_CASE")


### PR DESCRIPTION
The client currently used to talk to Community API will need the new role of ROLE_DELIUS_USER_DETAILS. Once the changes are deployed you can then remove ROLE_COMMUNITY_AUTH_INT.