### PR TITLE
HAAR-1943: Use local service client to invoke Auth

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/adapter/auth/AuthApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/adapter/auth/AuthApiService.kt
@@ -92,7 +92,7 @@ class AuthApiService(
   fun updateEmail(username: String, newEmailAddress: String) =
     userWebClientUtils.put("/api/prisonuser/$username/email", mapOf("email" to newEmailAddress))
 
-  fun findUserEmails(usernames: List<String>): List<EmailAddress> = userWebClientUtils.postWithResponse(
+  fun findUserEmails(usernames: List<String>): List<EmailAddress> = serviceWebClientUtils.postWithResponse(
     "/api/prisonuser/email",
     usernames,
     EmailList::class.java,


### PR DESCRIPTION
Use local service client to invoke Auth '/api/prisonuser/email' endpoint