### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/hmpps-manage-users-api/Chart.yaml
+++ b/helm_deploy/hmpps-manage-users-api/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.2.0
 
 dependencies:
   - name: generic-service
-    version: 2.7
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3

--- a/helm_deploy/hmpps-manage-users-api/values.yaml
+++ b/helm_deploy/hmpps-manage-users-api/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-manage-users-api
   productId: DPS017
@@ -7,12 +6,12 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-manage-users-api
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-manage-users-api-cert
     path: /
 
@@ -45,7 +44,6 @@ generic-service:
     DELIUS_ROLES_MAPPINGS_MRDBT002: "ROLE_MAKE_RECALL_DECISION_SPO"
     DELIUS_ROLES_MAPPINGS_TCBT006: "ROLE_RESETTLEMENT_PASSPORT_EDIT"
 
-
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
   #   [name of kubernetes secret]:
@@ -65,14 +63,8 @@ generic-service:
       APPLICATION_NOTIFY_KEY: "APPLICATION_NOTIFY_KEY"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   targetApplication: hmpps-manage-users-api

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-manage-users-api/values.yaml
 
 generic-service:
@@ -19,13 +18,10 @@ generic-service:
     BANNER_EMPTY:
     BANNER_DPSMENU:
 
-  allowlist:
-    hpa-iis-stage-1: "51.141.36.127/32"
-    hpa-iis-stage-2: "51.141.34.169/32"
-    hpa-iis-stage-3: "51.141.33.76/32"
-    hpa-iis-stage-4: "51.141.38.101/32"
-    hpa-iis-stage-5: "51.140.210.98/32"
 
+  allowlist:
+    undefined: 51.140.210.98/32
+    groups: []
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-manage-users-api/values.yaml
 
 generic-service:
@@ -19,12 +18,10 @@ generic-service:
     BANNER_EMPTY:
     BANNER_DPSMENU:
 
+
   allowlist:
-    hpa-iis-preprod-1: "51.141.36.127/32"
-    hpa-iis-preprod-2: "51.141.34.169/32"
-    hpa-iis-preprod-3: "51.141.33.76/32"
-    hpa-iis-preprod-4: "51.141.38.101/32"
-    hpa-iis-preprod-5: "51.140.210.98/32"
+    undefined: 51.140.210.98/32
+    groups: []
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-manage-users-api/values.yaml
 
 generic-service:
@@ -18,13 +17,10 @@ generic-service:
     BANNER_EMPTY:
     BANNER_DPSMENU:
 
-  allowlist:
-    hpa-iis-prod-1: "51.141.12.82/32"
-    hpa-iis-prod-2: "51.141.12.83/32"
-    hpa-iis-prod-3: "51.141.12.84/32"
-    hpa-iis-prod-4: "51.141.12.85/32"
-    hpa-iis-prod-5: "51.140.210.97/32"
 
+  allowlist:
+    undefined: 51.140.210.97/32
+    groups: []
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 generic-prometheus-alerts:


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

4 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-manage-users-api/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `8 => 0 (8 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

## Allowlist: helm_deploy/values-dev.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `5 => 5 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  

## Allowlist: helm_deploy/values-preprod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `5 => 5 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  

## Allowlist: helm_deploy/values-prod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `5 => 5 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  
