### PR TITLE
HAAR-2658: Remove retries for download users to reduce impact on nomis user roles api

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/config/NomisWebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/config/NomisWebClientConfiguration.kt
@@ -16,6 +16,8 @@ class NomisWebClientConfiguration(appContext: ApplicationContext) :
   private val environment = appContext.environment
 
   private val maxRetryAttempts = environment.getRequiredProperty("nomis.max-retry-attempts", Long::class.java)
+  private val extendedTimeoutMaxRetryAttempts =
+    environment.getRequiredProperty("nomis.extended-timeout-max-retry-attempts", Long::class.java)
 
   @Bean("nomisClientRegistration")
   fun getNomisClientRegistration(): ClientRegistration = getClientRegistration()
@@ -40,5 +42,6 @@ class NomisWebClientConfiguration(appContext: ApplicationContext) :
   fun nomisUserWebClientUtils(nomisUserWebClient: WebClient) = WebClientUtils(nomisUserWebClient, maxRetryAttempts)
 
   @Bean
-  fun nomisUserExtendedTimeoutWebClientUtils(nomisUserExtendedTimeoutWebClient: WebClient) = WebClientUtils(nomisUserExtendedTimeoutWebClient, maxRetryAttempts)
+  fun nomisUserExtendedTimeoutWebClientUtils(nomisUserExtendedTimeoutWebClient: WebClient) =
+    WebClientUtils(nomisUserExtendedTimeoutWebClient, extendedTimeoutMaxRetryAttempts)
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -120,6 +120,7 @@ nomis:
     timeout: 5s
     extended-timeout: 3m
   max-retry-attempts: 2
+  extended-timeout-max-retry-attempts: 0
 
 external-users:
   enabled: false


### PR DESCRIPTION
Do not attempt retries for download user calls to nomis user roles as it is currently possible to cause an out of memory error so any retries could possibly cause multiple pods to fail - with zero reties worst case is that only 1 pod would fail.