### PR TITLE
HAAR-3920: expose the authSource in the User interface

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/UserController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/UserController.kt
@@ -79,7 +79,7 @@ class UserController(
     val user = userService.findUserByUsernameWithAuthSource(authenticationFacade.currentUsername!!)
     return user?.let {
       UserDetailsDto.fromDomain(user)
-    } ?: UsernameDto(authenticationFacade.currentUsername!!)
+    } ?: UsernameDto(authenticationFacade.currentUsername!!, authenticationFacade.authSource)
   }
 
   @GetMapping("/users/me/groups")
@@ -224,10 +224,12 @@ data class UserRole(
 
 interface User {
   val username: String
+  val authSource: AuthSource
 }
 
 data class UsernameDto(
   override val username: String,
+  override val authSource: AuthSource,
 ) : User
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -258,7 +260,7 @@ data class UserDetailsDto(
   var name: String,
 
   @Schema(title = "Authentication Source", description = "auth for external users, nomis for nomis authenticated users", example = "nomis")
-  var authSource: AuthSource,
+  override val authSource: AuthSource,
 
   @Deprecated("")
   @Schema(title = "Staff Id", description = "Deprecated, use userId instead", example = "231232")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/UserControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/UserControllerIntTest.kt
@@ -283,6 +283,7 @@ class UserControllerIntTest : IntegrationTestBase() {
           assertThat(it).containsExactlyEntriesOf(
             mapOf(
               "username" to "basicuser",
+              "authSource" to "none",
             ),
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/UserControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/UserControllerTest.kt
@@ -71,7 +71,8 @@ class UserControllerTest {
   @Test
   fun `find my details for basic user`() {
     whenever(authenticationFacade.currentUsername).thenReturn("me")
-    val userDetails = UsernameDto("me")
+    whenever(authenticationFacade.authSource).thenReturn(auth)
+    val userDetails = UsernameDto("me", auth)
     whenever(userService.findUserByUsernameWithAuthSource("me")).thenReturn(null)
 
     val user = userController.myDetails()


### PR DESCRIPTION
This is useful in the changes I'm doing in manage users to only get the nomis details if the authSource is nomis. This actually comes back in the type from `/users/me` but the interface is returned which only includes the username