### PR TITLE
MAP-2750 Add integration tests and update access control for user search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/prison/UserController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/prison/UserController.kt
@@ -54,11 +54,11 @@ class UserSearchController(
   private val authenticationFacade: AuthenticationFacade,
   @Value("\${application.smoketest.enabled}") private val smokeTestEnabled: Boolean,
 ) {
-  @PreAuthorize("hasRole('ROLE_MAINTAIN_ACCESS_ROLES_ADMIN') or hasRole('ROLE_MAINTAIN_ACCESS_ROLES')")
+  @PreAuthorize("hasAnyRole('ROLE_MAINTAIN_ACCESS_ROLES_ADMIN', 'ROLE_MAINTAIN_ACCESS_ROLES', 'ROLE_STAFF_SEARCH')")
   @GetMapping("/prisonusers/search")
   @Operation(
     summary = "Get all users filtered as specified",
-    description = "Requires role ROLE_MAINTAIN_ACCESS_ROLES_ADMIN or ROLE_MAINTAIN_ACCESS_ROLES. <br/>Get all users with filter.<br/> For local administrators this will implicitly filter users in the prisons they administer, therefore username is expected in the authorisation token. <br/>For users with role ROLE_MAINTAIN_ACCESS_ROLES_ADMIN this allows access to all staff.",
+    description = "Requires role ROLE_MAINTAIN_ACCESS_ROLES_ADMIN, ROLE_MAINTAIN_ACCESS_ROLES or ROLE_STAFF_SEARCH. <br/>Get all users with filter.<br/> For local administrators this will implicitly filter users in the prisons they administer, therefore username is expected in the authorisation token. <br/>For users with role ROLE_MAINTAIN_ACCESS_ROLES_ADMIN this allows access to all staff.",
     responses = [
       ApiResponse(
         responseCode = "200",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/prison/UserControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/prison/UserControllerIntTest.kt
@@ -1482,6 +1482,19 @@ class UserControllerIntTest : IntegrationTestBase() {
         getRequestedFor(urlEqualTo(nomisUri)),
       )
     }
+
+    @Test
+    fun `findUsersWithFilter calls find-users endpoint using service client`() {
+      nomisApiMockServer.stubFindUsersByFilter(nomisUri, OK)
+      webTestClient.get().uri(localUri)
+        .headers(setAuthorisation(roles = listOf("ROLE_STAFF_SEARCH")))
+        .exchange()
+        .expectStatus().isOk
+
+      nomisApiMockServer.verify(
+        getRequestedFor(urlEqualTo(nomisUri)),
+      )
+    }
   }
 
   @Nested


### PR DESCRIPTION
### What has changed

- Added an integration test for the `find-users` endpoint, validating functionality with service client verification.
- Updated access control logic to include `ROLE_STAFF_SEARCH` for prison user searches.
- Adjusted logic for client selection in the `UserApiService` allow service client calls when STAFF_SEARCH role is present.

### Why is this change necessary?

To ensure proper functionality with enhanced testing and to secure appropriate access control for prison user searches.

### Checklist

- [ ] Unit tests have been added where applicable.
- [ ] Functions and variables have been properly commented/documented.
- [ ] Relevant documentation has been updated.