### PR TITLE
Extend access control for prison user details endpoint.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/prison/UserController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/prison/UserController.kt
@@ -401,14 +401,17 @@ class UserController(
   ) = NewPrisonUserDto.fromDomain(prisonUserService.createUser(createUserRequest))
 
   @GetMapping("/prisonusers/{username}", produces = [MediaType.APPLICATION_JSON_VALUE])
-  @PreAuthorize("hasAnyRole('ROLE_MAINTAIN_ACCESS_ROLES_ADMIN', 'ROLE_MAINTAIN_ACCESS_ROLES', 'ROLE_MANAGE_NOMIS_USER_ACCOUNT')")
+  @PreAuthorize("hasAnyRole('ROLE_MAINTAIN_ACCESS_ROLES_ADMIN', 'ROLE_MAINTAIN_ACCESS_ROLES', 'ROLE_MANAGE_NOMIS_USER_ACCOUNT', 'ROLE_STAFF_SEARCH')")
   @Operation(
     summary = "Get specified user details",
-    description = "Information on a specific user. Requires role ROLE_MAINTAIN_ACCESS_ROLES_ADMIN or ROLE_MAINTAIN_ACCESS_ROLES or ROLE_MANAGE_NOMIS_USER_ACCOUNT",
+    description = "Information on a specific user. Requires role ROLE_MAINTAIN_ACCESS_ROLES_ADMIN, ROLE_MAINTAIN_ACCESS_ROLES, ROLE_MANAGE_NOMIS_USER_ACCOUNT or ROLE_STAFF_SEARCH",
     security = [
       SecurityRequirement(name = "ROLE_MAINTAIN_ACCESS_ROLES_ADMIN"), SecurityRequirement(name = "ROLE_MAINTAIN_ACCESS_ROLES"),
       SecurityRequirement(
         name = "ROLE_MANAGE_NOMIS_USER_ACCOUNT",
+      ),
+      SecurityRequirement(
+        name = "ROLE_STAFF_SEARCH",
       ),
     ],
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/prison/UserControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/prison/UserControllerIntTest.kt
@@ -1237,10 +1237,17 @@ class UserControllerIntTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `find user by username`() {
+    fun `find user by username with allowed roles`() {
+      for (role in listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN", "ROLE_MAINTAIN_ACCESS_ROLES", "ROLE_MANAGE_NOMIS_USER_ACCOUNT", "ROLE_STAFF_SEARCH")) {
+        testUserDetailsCanBeObtainedWithRole(role)
+      }
+    }
+
+    private fun testUserDetailsCanBeObtainedWithRole(roleToUse: String) {
       nomisApiMockServer.stubFindUserByUsername(username)
+
       val prisonUser = webTestClient.get().uri("/prisonusers/$username")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+        .headers(setAuthorisation(roles = listOf(roleToUse)))
         .exchange()
         .expectStatus().isOk
         .expectBody(NewPrisonUserDto::class.java)


### PR DESCRIPTION
```markdown
### What does this pull request do?

This pull request extends the access control for the prison user details endpoint to include the `ROLE_STAFF_SEARCH` role. Additionally, it updates the related integration tests to reflect this change.

### Why is this change important?

This change ensures that users with the `ROLE_STAFF_SEARCH` role have the necessary access to fetch prison user details, supporting broader staff functionality.

### Implementation Notes

- Updated access control to include `ROLE_STAFF_SEARCH`.
- Modified and verified integration tests to align with the updated access control logic.
  
### Types of Changes

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Other (please describe): 

### How has this been tested?

- Integration tests were updated and run successfully to validate changes.

### Checklist

- [ ] Documentation has been updated if needed.
- [x] Tests have been added or updated as necessary.
- [ ] The code follows coding standards and has been reviewed.
```