### PR TITLE
Replace create_app_version action with hmpps-github-shared-actions v1

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - id: app_version
         name: Application version creators
-        uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/build-test-and-deploy/create_app_version@f52dbae537425d92f2216c4a2d9e0e44e603abb1 #v1
+        uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/build-test-and-deploy/create_app_version@f52dbae537425d92f2216c4a2d9e0e44e603abb1 # v1
   gradle_verify:
     name: Validate the kotlin
     uses: ./.github/workflows/gradle_verify.yml

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - id: app_version
         name: Application version creators
-        uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/create_app_version@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d # v2
+        uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/build-test-and-deploy/create_app_version@f52dbae537425d92f2216c4a2d9e0e44e603abb1 #v1
   gradle_verify:
     name: Validate the kotlin
     uses: ./.github/workflows/gradle_verify.yml


### PR DESCRIPTION
## What
Replaces old `create_app_version` action references in `pipeline.yml` with:
- `ministryofjustice/hmpps-github-shared-actions/.github/actions/build-test-and-deploy/create_app_version@f52dbae537425d92f2216c4a2d9e0e44e603abb1 #v1`

## Why
The shared actions have moved repository.

## Notes
- Only updates `.github/workflows/pipeline.yml`
- Converts any existing ref/hash/version for `create_app_version`