### PR TITLE
HAAR-5580: Process bulk item messages to assign role to user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/ManageUsersApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/ManageUsersApi.kt
@@ -4,10 +4,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.data.web.config.EnableSpringDataWebSupport
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication()
 @ConfigurationPropertiesScan
 @EnableSpringDataWebSupport
+@EnableScheduling
 class ManageUsersApi
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/event/BulkUserJobItemListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/event/BulkUserJobItemListener.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.manageusersapi.event
+
+import io.awspring.cloud.sqs.annotation.SqsListener
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.manageusersapi.service.bulkjob.BulkUserJobItemRoleAssignmentService
+
+@Service
+class BulkUserJobItemListener(
+  private val bulkUserJobItemRoleAssignmentService: BulkUserJobItemRoleAssignmentService,
+) {
+  @SqsListener(value = ["bulkuserjobitemqueue"], factory = "hmppsQueueContainerFactoryProxy")
+  fun onBulkUserJobItemMessage(message: BulkUserJobItemMessage) {
+    bulkUserJobItemRoleAssignmentService.processRoleAssignmentMessage(message)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/repository/BulkUserJobItemRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/repository/BulkUserJobItemRepository.kt
@@ -16,6 +16,7 @@ import java.util.stream.Stream
 interface BulkUserJobItemRepository : JpaRepository<BulkUserJobItem, UUID> {
 
   fun streamByBulkUserJobId(jobId: UUID): Stream<BulkUserJobItem>
+  fun findByBulkUserJobIdAndStatusAndClaimedAtBefore(jobId: UUID, status: BulkUserJobItemStatus, claimedAt: Instant): List<BulkUserJobItem>
 
   @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)
@@ -31,6 +32,25 @@ interface BulkUserJobItemRepository : JpaRepository<BulkUserJobItem, UUID> {
     @Param("jobItemId") jobItemId: UUID,
     @Param("currentStatus") currentStatus: BulkUserJobItemStatus,
     @Param("newStatus") newStatus: BulkUserJobItemStatus,
-    @Param("claimedAt") claimedAt: Instant?,
+    @Param("claimedAt") claimedAt: Instant? = null,
+  ): Int
+
+  @Transactional
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+    """
+      UPDATE BulkUserJobItem i
+      SET i.status = :newStatus
+        , i.result = :result
+        , i.claimedAt = :claimedAt
+      WHERE i.id = :jobItemId AND i.status = :currentStatus
+    """,
+  )
+  fun updateStatusAndResultIfCurrent(
+    @Param("jobItemId") jobItemId: UUID,
+    @Param("currentStatus") currentStatus: BulkUserJobItemStatus,
+    @Param("newStatus") newStatus: BulkUserJobItemStatus,
+    @Param("result") result: String? = null,
+    @Param("claimedAt") claimedAt: Instant? = null,
   ): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/repository/BulkUserJobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/repository/BulkUserJobRepository.kt
@@ -3,9 +3,11 @@ package uk.gov.justice.digital.hmpps.manageusersapi.repository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJob
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobDetails
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus
@@ -74,4 +76,29 @@ interface BulkUserJobRepository : JpaRepository<BulkUserJob, UUID> {
     @Param("statusComplete") status: BulkUserJobStatus = BulkUserJobStatus.COMPLETE,
     @Param("jobItemStatuses") jobItemStatuses: Set<BulkUserJobItemStatus> = setOf(BulkUserJobItemStatus.SUCCESS, BulkUserJobItemStatus.ERROR),
   ): UUID?
+
+  @Transactional
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+    """
+      UPDATE BulkUserJob b
+      SET b.status = 'COMPLETE'
+      WHERE b.id = :jobId
+        AND b.status != 'COMPLETE'
+        AND NOT EXISTS (
+          SELECT i FROM BulkUserJobItem i
+          WHERE i.bulkUserJob.id = b.id
+            AND i.status NOT IN ('SUCCESS', 'ERROR')
+        )
+    """,
+  )
+  fun markCompleteIfAllItemsTerminal(@Param("jobId") jobId: UUID): Int
+
+  @Query(
+    """
+      SELECT b.id FROM BulkUserJob b
+      WHERE b.status != 'COMPLETE'
+    """,
+  )
+  fun findIncompleteJobIds(): List<UUID>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/scheduled/BulkUserJobReconciler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/scheduled/BulkUserJobReconciler.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.manageusersapi.scheduled
+
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.BulkUserJobRepository
+import uk.gov.justice.digital.hmpps.manageusersapi.service.bulkjob.BulkUserJobReconciliationService
+
+@Component
+class BulkUserJobReconciler(
+  private val bulkUserJobRepository: BulkUserJobRepository,
+  private val bulkUserJobReconciliationService: BulkUserJobReconciliationService,
+) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Scheduled(
+    initialDelayString = "\${application.bulk-jobs.reconciliation-interval}",
+    fixedDelayString = "\${application.bulk-jobs.reconciliation-interval}",
+  )
+  fun reconcileIncompleteJobs() {
+    val incompleteJobIds = bulkUserJobRepository.findIncompleteJobIds()
+    if (incompleteJobIds.isEmpty()) return
+
+    log.info("Reconciling {} incomplete bulk user job(s)", incompleteJobIds.size)
+    incompleteJobIds.forEach { jobId ->
+      try {
+        bulkUserJobReconciliationService.reconcileBulkJob(jobId)
+      } catch (e: Exception) {
+        log.error("Failed to reconcile bulk user job {}", jobId, e)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemRoleAssignmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemRoleAssignmentService.kt
@@ -1,0 +1,91 @@
+package uk.gov.justice.digital.hmpps.manageusersapi.service.bulkjob
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.manageusersapi.event.BulkUserJobItemMessage
+import uk.gov.justice.digital.hmpps.manageusersapi.model.DPS_CASELOAD
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.BulkUserJobItemRepository
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItem
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus
+import uk.gov.justice.digital.hmpps.manageusersapi.service.prison.UserRolesService
+import java.util.UUID
+
+@Service
+class BulkUserJobItemRoleAssignmentService(
+  private val bulkUserJobItemRepository: BulkUserJobItemRepository,
+  private val userRolesService: UserRolesService,
+  private val bulkUserJobReconciliationService: BulkUserJobReconciliationService,
+) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+    private const val USER_NOT_FOUND = "User not found"
+    private const val ROLE_ALREADY_ASSIGNED = "Role already assigned"
+    private const val SYSTEM_ISSUE = "System issue"
+  }
+
+  fun processRoleAssignmentMessage(message: BulkUserJobItemMessage) {
+    if (!claimForAssignment(message.jobItemId)) {
+      log.info("Skipping bulk user job item {} because it is not in PUBLISHED status", message.jobItemId)
+      return
+    }
+
+    val item = bulkUserJobItemRepository.findById(message.jobItemId)
+      .orElseThrow { IllegalStateException("Bulk user job item ${message.jobItemId} not found") }
+
+    if (!messageMatchesPersistedItem(message, item)) {
+      markError(item.id, SYSTEM_ISSUE)
+      bulkUserJobReconciliationService.reconcileBulkJob(item.bulkUserJob.id)
+      log.warn("Received mismatched payload for bulk user job item {}", item.id)
+      return
+    }
+
+    val username = item.username.uppercase()
+    val roleCode = item.rolename.uppercase()
+
+    try {
+      userRolesService.addRolesToUser(username, listOf(roleCode), DPS_CASELOAD)
+      markSuccess(item.id)
+      bulkUserJobReconciliationService.reconcileBulkJob(item.bulkUserJob.id)
+    } catch (e: WebClientResponseException.NotFound) {
+      markError(item.id, USER_NOT_FOUND)
+      bulkUserJobReconciliationService.reconcileBulkJob(item.bulkUserJob.id)
+    } catch (e: WebClientResponseException.Conflict) {
+      markError(item.id, ROLE_ALREADY_ASSIGNED)
+      bulkUserJobReconciliationService.reconcileBulkJob(item.bulkUserJob.id)
+    } catch (e: Exception) {
+      markError(item.id, SYSTEM_ISSUE)
+      bulkUserJobReconciliationService.reconcileBulkJob(item.bulkUserJob.id)
+      log.error("Role assignment failed for bulk user job item {}", item.id, e)
+    }
+  }
+
+  private fun claimForAssignment(jobItemId: UUID): Boolean = bulkUserJobItemRepository.updateStatusIfCurrent(
+    jobItemId = jobItemId,
+    currentStatus = BulkUserJobItemStatus.PUBLISHED,
+    newStatus = BulkUserJobItemStatus.STARTED,
+  ) == 1
+
+  private fun markSuccess(jobItemId: UUID) {
+    val updatedRows = bulkUserJobItemRepository.updateStatusAndResultIfCurrent(
+      jobItemId = jobItemId,
+      currentStatus = BulkUserJobItemStatus.STARTED,
+      newStatus = BulkUserJobItemStatus.SUCCESS,
+    )
+    check(updatedRows == 1) { "Bulk user job item $jobItemId could not be marked as SUCCESS from STARTED" }
+  }
+
+  private fun markError(jobItemId: UUID, reason: String) {
+    val updatedRows = bulkUserJobItemRepository.updateStatusAndResultIfCurrent(
+      jobItemId = jobItemId,
+      currentStatus = BulkUserJobItemStatus.STARTED,
+      newStatus = BulkUserJobItemStatus.ERROR,
+      result = reason,
+    )
+    check(updatedRows == 1) { "Bulk user job item $jobItemId could not be marked as ERROR from STARTED" }
+  }
+
+  private fun messageMatchesPersistedItem(message: BulkUserJobItemMessage, item: BulkUserJobItem): Boolean = message.jobId == item.bulkUserJob.id &&
+    message.username.equals(item.username, ignoreCase = true) &&
+    message.rolename.equals(item.rolename, ignoreCase = true)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemRoleAssignmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemRoleAssignmentService.kt
@@ -20,18 +20,23 @@ class BulkUserJobItemRoleAssignmentService(
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
     private const val USER_NOT_FOUND = "User not found"
-    private const val ROLE_ALREADY_ASSIGNED = "Role already assigned"
     private const val SYSTEM_ISSUE = "System issue"
   }
 
   fun processRoleAssignmentMessage(message: BulkUserJobItemMessage) {
-    if (!claimForAssignment(message.jobItemId)) {
-      log.info("Skipping bulk user job item {} because it is not in PUBLISHED status", message.jobItemId)
+    val item = bulkUserJobItemRepository.findById(message.jobItemId).orElse(null)
+    if (item == null) {
+      log.warn("Skipping bulk user job item {} because it no longer exists", message.jobItemId)
       return
     }
 
-    val item = bulkUserJobItemRepository.findById(message.jobItemId)
-      .orElseThrow { IllegalStateException("Bulk user job item ${message.jobItemId} not found") }
+    if (!claimForAssignment(item)) {
+      log.info(
+        "Skipping bulk user job item {} because it is not awaiting assignment (already in a terminal state or not yet published)",
+        message.jobItemId,
+      )
+      return
+    }
 
     if (!messageMatchesPersistedItem(message, item)) {
       markError(item.id, SYSTEM_ISSUE)
@@ -51,7 +56,9 @@ class BulkUserJobItemRoleAssignmentService(
       markError(item.id, USER_NOT_FOUND)
       bulkUserJobReconciliationService.reconcileBulkJob(item.bulkUserJob.id)
     } catch (e: WebClientResponseException.Conflict) {
-      markError(item.id, ROLE_ALREADY_ASSIGNED)
+      // The user already has the role (either pre-existing, or assigned by a previous processing of this message that
+      // failed before recording success), so treat it as a successful assignment
+      markSuccess(item.id)
       bulkUserJobReconciliationService.reconcileBulkJob(item.bulkUserJob.id)
     } catch (e: Exception) {
       markError(item.id, SYSTEM_ISSUE)
@@ -60,11 +67,22 @@ class BulkUserJobItemRoleAssignmentService(
     }
   }
 
-  private fun claimForAssignment(jobItemId: UUID): Boolean = bulkUserJobItemRepository.updateStatusIfCurrent(
-    jobItemId = jobItemId,
-    currentStatus = BulkUserJobItemStatus.PUBLISHED,
-    newStatus = BulkUserJobItemStatus.STARTED,
-  ) == 1
+  private fun claimForAssignment(item: BulkUserJobItem): Boolean {
+    // This might be a recovery so if the item was already started then no need to set the status as started,
+    // otherwise claim by changing from published to started.
+    val alreadyStarted = item.status == BulkUserJobItemStatus.STARTED
+    if (!alreadyStarted) {
+      val claimedFromPublished = bulkUserJobItemRepository.updateStatusIfCurrent(
+        jobItemId = item.id,
+        currentStatus = BulkUserJobItemStatus.PUBLISHED,
+        newStatus = BulkUserJobItemStatus.STARTED,
+      ) == 1
+      if (claimedFromPublished) {
+        return true
+      }
+    }
+    return alreadyStarted
+  }
 
   private fun markSuccess(jobItemId: UUID) {
     val updatedRows = bulkUserJobItemRepository.updateStatusAndResultIfCurrent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemService.kt
@@ -37,6 +37,30 @@ class BulkUserJobItemService(
     markPublished(item.id)
   }
 
+  fun republishStaleClaimedItem(job: BulkUserJob, item: BulkUserJobItem) {
+    val refreshed = bulkUserJobItemRepository.updateStatusIfCurrent(
+      jobItemId = item.id,
+      currentStatus = BulkUserJobItemStatus.CLAIMED,
+      newStatus = BulkUserJobItemStatus.CLAIMED,
+      claimedAt = Instant.now(),
+    ) == 1
+    if (!refreshed) {
+      log.info("Skipping stale re-publish of bulk user job item {} because it is no longer CLAIMED", item.id)
+      return
+    }
+
+    bulkUserJobItemPublisher.publishBulkUserJobItemEvent(job, item)
+
+    val published = bulkUserJobItemRepository.updateStatusIfCurrent(
+      jobItemId = item.id,
+      currentStatus = BulkUserJobItemStatus.CLAIMED,
+      newStatus = BulkUserJobItemStatus.PUBLISHED,
+    ) == 1
+    if (!published) {
+      log.warn("Re-published stale bulk user job item {} but could not mark it PUBLISHED as its status changed concurrently", item.id)
+    }
+  }
+
   private fun claimJobItem(jobItemId: UUID): Instant? {
     val claimedAt = Instant.now()
     val updatedRows = bulkUserJobItemRepository.updateStatusIfCurrent(
@@ -53,7 +77,6 @@ class BulkUserJobItemService(
       jobItemId = jobItemId,
       currentStatus = BulkUserJobItemStatus.CLAIMED,
       newStatus = BulkUserJobItemStatus.CREATED,
-      claimedAt = null,
     )
   }
 
@@ -62,7 +85,6 @@ class BulkUserJobItemService(
       jobItemId = jobItemId,
       currentStatus = BulkUserJobItemStatus.CLAIMED,
       newStatus = BulkUserJobItemStatus.PUBLISHED,
-      claimedAt = null,
     )
     check(updatedRows == 1) { "Bulk user job item $jobItemId could not be marked as PUBLISHED from CLAIMED" }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemService.kt
@@ -38,6 +38,7 @@ class BulkUserJobItemService(
   }
 
   fun republishStaleClaimedItem(job: BulkUserJob, item: BulkUserJobItem) {
+    val originalClaimedAt = item.claimedAt ?: Instant.EPOCH
     val refreshed = bulkUserJobItemRepository.updateStatusIfCurrent(
       jobItemId = item.id,
       currentStatus = BulkUserJobItemStatus.CLAIMED,
@@ -49,7 +50,17 @@ class BulkUserJobItemService(
       return
     }
 
-    bulkUserJobItemPublisher.publishBulkUserJobItemEvent(job, item)
+    try {
+      bulkUserJobItemPublisher.publishBulkUserJobItemEvent(job, item)
+    } catch (e: Exception) {
+      bulkUserJobItemRepository.updateStatusIfCurrent(
+        jobItemId = item.id,
+        currentStatus = BulkUserJobItemStatus.CLAIMED,
+        newStatus = BulkUserJobItemStatus.CLAIMED,
+        claimedAt = originalClaimedAt,
+      )
+      throw e
+    }
 
     val published = bulkUserJobItemRepository.updateStatusIfCurrent(
       jobItemId = item.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobReconciliationService.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.manageusersapi.service.bulkjob
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.BulkUserJobItemRepository
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.BulkUserJobRepository
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+@Service
+class BulkUserJobReconciliationService(
+  private val bulkUserJobItemRepository: BulkUserJobItemRepository,
+  private val bulkUserJobRepository: BulkUserJobRepository,
+  private val bulkUserJobItemService: BulkUserJobItemService,
+  @Value("\${application.bulk-jobs.stale-claimed-threshold}") private val staleClaimedThreshold: Duration,
+) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun reconcileBulkJob(jobId: UUID) {
+    republishStaleClaimedItems(jobId)
+    val updatedRows = bulkUserJobRepository.markCompleteIfAllItemsTerminal(jobId)
+    if (updatedRows == 1) {
+      log.info("Marked bulk user job {} as COMPLETE", jobId)
+    }
+  }
+
+  private fun republishStaleClaimedItems(jobId: UUID) {
+    val staleClaimCutoff = Instant.now().minus(staleClaimedThreshold)
+    val staleClaimedItems = bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndClaimedAtBefore(
+      jobId = jobId,
+      status = BulkUserJobItemStatus.CLAIMED,
+      claimedAt = staleClaimCutoff,
+    )
+    if (staleClaimedItems.isEmpty()) return
+
+    val job = bulkUserJobRepository.findWithJobItemsById(jobId)
+      .orElseThrow { IllegalStateException("Bulk user job $jobId not found when republishing stale claimed items") }
+
+    staleClaimedItems.forEach { staleItem ->
+      try {
+        log.warn("Re-publishing stale claimed bulk user job item {} for job {}", staleItem.id, jobId)
+        bulkUserJobItemService.republishStaleClaimedItem(job, staleItem)
+      } catch (e: Exception) {
+        log.error(
+          "Failed to re-publish stale claimed bulk user job item {}; it remains CLAIMED and will be retried",
+          staleItem.id,
+          e,
+        )
+      }
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -111,6 +111,10 @@ application:
 
   smoketest.enabled: false
 
+  bulk-jobs:
+    stale-claimed-threshold: PT1H
+    reconciliation-interval: PT5M
+
 authorization-server:
   token:
     endpoint:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/event/BulkUserJobItemListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/event/BulkUserJobItemListenerTest.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.manageusersapi.event
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.manageusersapi.service.bulkjob.BulkUserJobItemRoleAssignmentService
+import java.util.UUID
+
+class BulkUserJobItemListenerTest {
+  private val bulkUserJobItemRoleAssignmentService: BulkUserJobItemRoleAssignmentService = mock()
+  private val listener = BulkUserJobItemListener(bulkUserJobItemRoleAssignmentService)
+
+  @Test
+  fun `should delegate message processing to role assignment service`() {
+    val message = BulkUserJobItemMessage(
+      jobId = UUID.randomUUID(),
+      jobItemId = UUID.randomUUID(),
+      username = "USER123",
+      rolename = "ROLE_ONE",
+      jiraReference = "JIRA-123",
+      requestedBy = "userabc",
+    )
+
+    listener.onBulkUserJobItemMessage(message)
+
+    verify(bulkUserJobItemRoleAssignmentService).processRoleAssignmentMessage(message)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/repository/BulkUserJobItemRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/repository/BulkUserJobItemRepositoryTest.kt
@@ -10,7 +10,15 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJob
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItem
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus.CLAIMED
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus.CREATED
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus.ERROR
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus.PUBLISHED
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus.STARTED
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus.SUCCESS
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobStatus
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobStatus.COMPLETE
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobStatus.PENDING
 import java.time.Instant
 import java.time.LocalDateTime
 import java.util.UUID
@@ -31,11 +39,10 @@ class BulkUserJobItemRepositoryTest(
 
   @Nested
   inner class FindByUserId {
-
     @Test
     fun `should find by Id`() {
-      val job = createBulkUserJobWithStatus(BulkUserJobStatus.PENDING)
-      val jobItem = createJobItemWithStatus(job, 1, BulkUserJobItemStatus.CREATED)
+      val job = createBulkUserJobWithStatus(PENDING)
+      val jobItem = createJobItemWithStatus(job, 1, CREATED)
       job.jobItems.add(jobItem)
 
       bulkUserJobRepository.saveAndFlush(job)
@@ -48,10 +55,9 @@ class BulkUserJobItemRepositoryTest(
 
   @Nested
   inner class StreamByBulkUserJobId {
-
     @Test
     fun `should return empty stream when no items exist for job id`() {
-      val job = createBulkUserJobWithStatus(BulkUserJobStatus.PENDING)
+      val job = createBulkUserJobWithStatus(PENDING)
       bulkUserJobRepository.saveAndFlush(job)
 
       bulkUserJobItemRepository.streamByBulkUserJobId(job.id).use { stream ->
@@ -61,11 +67,11 @@ class BulkUserJobItemRepositoryTest(
 
     @Test
     fun `should return stream for expected items`() {
-      val job = createBulkUserJobWithStatus(BulkUserJobStatus.COMPLETE)
+      val job = createBulkUserJobWithStatus(COMPLETE)
       val items = listOf(
-        createJobItemWithStatus(job, 1, BulkUserJobItemStatus.SUCCESS),
-        createJobItemWithStatus(job, 2, BulkUserJobItemStatus.ERROR),
-        createJobItemWithStatus(job, 3, BulkUserJobItemStatus.SUCCESS),
+        createJobItemWithStatus(job, 1, SUCCESS),
+        createJobItemWithStatus(job, 2, ERROR),
+        createJobItemWithStatus(job, 3, SUCCESS),
       )
       job.jobItems.addAll(items)
       bulkUserJobRepository.saveAndFlush(job)
@@ -82,7 +88,7 @@ class BulkUserJobItemRepositoryTest(
     fun `updateStatusIfCurrent sets claimedAt when claim succeeds`() {
       val job = BulkUserJob(
         id = UUID.fromString("11111111-1111-1111-1111-111111111111"),
-        status = BulkUserJobStatus.PENDING,
+        status = PENDING,
         jiraReference = "ABC-123",
         requestedBy = "Test",
       )
@@ -94,14 +100,14 @@ class BulkUserJobItemRepositoryTest(
 
       val updatedRows = bulkUserJobItemRepository.updateStatusIfCurrent(
         item.id,
-        BulkUserJobItemStatus.CREATED,
-        BulkUserJobItemStatus.CLAIMED,
+        CREATED,
+        CLAIMED,
         claimedAt,
       )
 
       assertThat(updatedRows).isEqualTo(1)
       assertThat(bulkUserJobItemRepository.findById(item.id)).isPresent.hasValueSatisfying {
-        assertThat(it.status).isEqualTo(BulkUserJobItemStatus.CLAIMED)
+        assertThat(it.status).isEqualTo(CLAIMED)
         assertThat(it.claimedAt).isEqualTo(claimedAt)
       }
     }
@@ -110,7 +116,7 @@ class BulkUserJobItemRepositoryTest(
     fun `updateStatusIfCurrent clears claimedAt when release succeeds`() {
       val job = BulkUserJob(
         id = UUID.fromString("22222222-2222-2222-2222-222222222222"),
-        status = BulkUserJobStatus.PENDING,
+        status = PENDING,
         jiraReference = "DEF-456",
         requestedBy = "Test",
       )
@@ -120,23 +126,13 @@ class BulkUserJobItemRepositoryTest(
       val item = job.jobItems.first()
       val claimedAt = Instant.parse("2025-11-24T09:53:03Z")
 
-      bulkUserJobItemRepository.updateStatusIfCurrent(
-        item.id,
-        BulkUserJobItemStatus.CREATED,
-        BulkUserJobItemStatus.CLAIMED,
-        claimedAt,
-      )
+      bulkUserJobItemRepository.updateStatusIfCurrent(item.id, CREATED, CLAIMED, claimedAt)
 
-      val updatedRows = bulkUserJobItemRepository.updateStatusIfCurrent(
-        item.id,
-        BulkUserJobItemStatus.CLAIMED,
-        BulkUserJobItemStatus.CREATED,
-        null,
-      )
+      val updatedRows = bulkUserJobItemRepository.updateStatusIfCurrent(item.id, CLAIMED, CREATED)
 
       assertThat(updatedRows).isEqualTo(1)
       assertThat(bulkUserJobItemRepository.findById(item.id)).isPresent.hasValueSatisfying {
-        assertThat(it.status).isEqualTo(BulkUserJobItemStatus.CREATED)
+        assertThat(it.status).isEqualTo(CREATED)
         assertThat(it.claimedAt).isNull()
       }
     }
@@ -145,7 +141,7 @@ class BulkUserJobItemRepositoryTest(
     fun `updateStatusIfCurrent does not update when current status does not match`() {
       val job = BulkUserJob(
         id = UUID.fromString("33333333-3333-3333-3333-333333333333"),
-        status = BulkUserJobStatus.PENDING,
+        status = PENDING,
         jiraReference = "GHI-789",
         requestedBy = "Test",
       )
@@ -154,18 +150,115 @@ class BulkUserJobItemRepositoryTest(
 
       val item = job.jobItems.first()
 
-      val updatedRows = bulkUserJobItemRepository.updateStatusIfCurrent(
-        item.id,
-        BulkUserJobItemStatus.PUBLISHED,
-        BulkUserJobItemStatus.CLAIMED,
-        Instant.parse("2025-11-24T09:53:03Z"),
-      )
+      val updatedRows = bulkUserJobItemRepository.updateStatusIfCurrent(item.id, PUBLISHED, CLAIMED, Instant.parse("2025-11-24T09:53:03Z"))
 
       assertThat(updatedRows).isEqualTo(0)
       assertThat(bulkUserJobItemRepository.findById(item.id)).isPresent.hasValueSatisfying {
-        assertThat(it.status).isEqualTo(BulkUserJobItemStatus.CREATED)
+        assertThat(it.status).isEqualTo(CREATED)
         assertThat(it.claimedAt).isNull()
       }
+    }
+  }
+
+  @Nested
+  inner class UpdateStatusAndResultIfCurrent {
+    @Test
+    fun `updateStatusAndResultIfCurrent sets status and result when state matches`() {
+      val job = createBulkUserJobWithStatus(PENDING)
+      val item = createJobItemWithStatus(job, 1, STARTED)
+      job.jobItems.add(item)
+      bulkUserJobRepository.saveAndFlush(job)
+
+      val updatedRows = bulkUserJobItemRepository.updateStatusAndResultIfCurrent(item.id, STARTED, ERROR, "System issue", null)
+
+      assertThat(updatedRows).isEqualTo(1)
+      assertThat(bulkUserJobItemRepository.findById(item.id)).isPresent.hasValueSatisfying {
+        assertThat(it.status).isEqualTo(ERROR)
+        assertThat(it.result).isEqualTo("System issue")
+      }
+    }
+
+    @Test
+    fun `updateStatusAndResultIfCurrent does not update when state does not match`() {
+      val job = createBulkUserJobWithStatus(PENDING)
+      val item = createJobItemWithStatus(job, 1, PUBLISHED)
+      job.jobItems.add(item)
+      bulkUserJobRepository.saveAndFlush(job)
+
+      val updatedRows = bulkUserJobItemRepository.updateStatusAndResultIfCurrent(item.id, STARTED, ERROR, "System issue", null)
+
+      assertThat(updatedRows).isEqualTo(0)
+      assertThat(bulkUserJobItemRepository.findById(item.id)).isPresent.hasValueSatisfying {
+        assertThat(it.status).isEqualTo(PUBLISHED)
+        assertThat(it.result).isNull()
+      }
+    }
+  }
+
+  @Nested
+  inner class FindByBulkUserJobIdAndStatusAndClaimedAtBefore {
+    private val cutoff: Instant = Instant.parse("2026-08-11T10:00:00Z")
+
+    @Test
+    fun `returns claimed items for the job claimed before the cutoff`() {
+      val job = createBulkUserJobWithStatus(PENDING)
+      val staleItem = createJobItemWithStatus(job, 1, CLAIMED).apply { claimedAt = cutoff.minusSeconds(60) }
+      job.jobItems.add(staleItem)
+      bulkUserJobRepository.saveAndFlush(job)
+
+      val actual = bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndClaimedAtBefore(job.id, CLAIMED, cutoff)
+
+      assertThat(actual).containsExactly(staleItem)
+    }
+
+    @Test
+    fun `excludes items claimed at or after the cutoff`() {
+      val job = createBulkUserJobWithStatus(PENDING)
+      job.jobItems.add(createJobItemWithStatus(job, 1, CLAIMED).apply { claimedAt = cutoff })
+      job.jobItems.add(createJobItemWithStatus(job, 2, CLAIMED).apply { claimedAt = cutoff.plusSeconds(60) })
+      bulkUserJobRepository.saveAndFlush(job)
+
+      val actual = bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndClaimedAtBefore(job.id, CLAIMED, cutoff)
+
+      assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `excludes items with a different status`() {
+      val job = createBulkUserJobWithStatus(PENDING)
+      job.jobItems.add(createJobItemWithStatus(job, 1, STARTED).apply { claimedAt = cutoff.minusSeconds(60) })
+      bulkUserJobRepository.saveAndFlush(job)
+
+      val actual = bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndClaimedAtBefore(job.id, CLAIMED, cutoff)
+
+      assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `excludes stale claimed items belonging to a different job`() {
+      val job = BulkUserJob(
+        id = UUID.fromString("11111111-1111-1111-1111-111111111111"),
+        status = PENDING,
+        jiraReference = "ABC-123",
+        requestedBy = "Test",
+        requestDateTime = requestTime,
+      )
+      val otherJob = BulkUserJob(
+        id = UUID.fromString("22222222-2222-2222-2222-222222222222"),
+        status = PENDING,
+        jiraReference = "DEF-456",
+        requestedBy = "Test",
+        requestDateTime = requestTime,
+      )
+      job.jobItems.add(createJobItemWithStatus(job, 1, CLAIMED).apply { claimedAt = cutoff.minusSeconds(60) })
+      otherJob.jobItems.add(createJobItemWithStatus(otherJob, 2, CLAIMED).apply { claimedAt = cutoff.minusSeconds(60) })
+      bulkUserJobRepository.saveAndFlush(job)
+      bulkUserJobRepository.saveAndFlush(otherJob)
+
+      val actual = bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndClaimedAtBefore(job.id, CLAIMED, cutoff)
+
+      assertThat(actual).hasSize(1)
+      assertThat(actual.first().bulkUserJob.id).isEqualTo(job.id)
     }
   }
 
@@ -177,13 +270,10 @@ class BulkUserJobItemRepositoryTest(
     requestDateTime = requestTime.plusHours(2),
   )
 
-  internal fun createJobItemWithStatus(job: BulkUserJob, index: Int, status: BulkUserJobItemStatus): BulkUserJobItem {
-    val item = BulkUserJobItem(
-      username = "user$index",
-      rolename = "role$index",
-      status = status,
-      bulkUserJob = job,
-    )
-    return item
-  }
+  private fun createJobItemWithStatus(job: BulkUserJob, index: Int, status: BulkUserJobItemStatus): BulkUserJobItem = BulkUserJobItem(
+    username = "user$index",
+    rolename = "role$index",
+    status = status,
+    bulkUserJob = job,
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/repository/BulkUserJobRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/repository/BulkUserJobRepositoryTest.kt
@@ -451,6 +451,60 @@ class BulkUserJobRepositoryTest {
     }
   }
 
+  @Nested
+  inner class MarkCompleteIfAllItemsTerminal {
+    @Test
+    fun `marks pending job complete when all items are success or error`() {
+      val job = createBulkUserJobWithStatus(BulkUserJobStatus.PENDING)
+      job.addJobItemWithStatus(1, BulkUserJobItemStatus.SUCCESS)
+      job.addJobItemWithStatus(2, BulkUserJobItemStatus.ERROR)
+      bulkUserJobRepository.saveAndFlush(job)
+
+      val updatedRows = bulkUserJobRepository.markCompleteIfAllItemsTerminal(job.id)
+
+      assertThat(updatedRows).isEqualTo(1)
+      assertThat(bulkUserJobRepository.findById(job.id)).isPresent.hasValueSatisfying {
+        assertThat(it.status).isEqualTo(BulkUserJobStatus.COMPLETE)
+      }
+    }
+
+    @Test
+    fun `does not mark complete when non-terminal items remain`() {
+      val job = createBulkUserJobWithStatus(BulkUserJobStatus.PENDING)
+      job.addJobItemWithStatus(1, BulkUserJobItemStatus.SUCCESS)
+      job.addJobItemWithStatus(2, BulkUserJobItemStatus.STARTED)
+      bulkUserJobRepository.saveAndFlush(job)
+
+      val updatedRows = bulkUserJobRepository.markCompleteIfAllItemsTerminal(job.id)
+
+      assertThat(updatedRows).isEqualTo(0)
+      assertThat(bulkUserJobRepository.findById(job.id)).isPresent.hasValueSatisfying {
+        assertThat(it.status).isEqualTo(BulkUserJobStatus.PENDING)
+      }
+    }
+  }
+
+  @Nested
+  inner class FindIncompleteJobIds {
+    @Test
+    fun `returns ids of jobs that are not complete`() {
+      givenBulkJobsExist()
+
+      val actual = bulkUserJobRepository.findIncompleteJobIds()
+
+      assertThat(actual).containsExactlyInAnyOrder(pendingBulkUserJob.id, pendingBulkUserJobTwo.id)
+    }
+
+    @Test
+    fun `returns empty list when all jobs are complete`() {
+      bulkUserJobRepository.save(completedBulkUserJob)
+
+      val actual = bulkUserJobRepository.findIncompleteJobIds()
+
+      assertThat(actual).isEmpty()
+    }
+  }
+
   private fun createBulkUserJobWithStatus(status: BulkUserJobStatus) = BulkUserJob(
     id = UUID.fromString("33333333-3333-3333-3333-333333333333"),
     status = status,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/bulkjob/BulkJobsControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/bulkjob/BulkJobsControllerIntTest.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.manageusersapi.resource.bulkjob
 
+import com.github.tomakehurst.wiremock.client.WireMock.containing
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import jakarta.transaction.Transactional
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.within
@@ -22,6 +25,7 @@ import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.test.web.reactive.server.EntityExchangeResult
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
+import org.springframework.test.web.reactive.server.returnResult
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.manageusersapi.config.SqsConfig
 import uk.gov.justice.digital.hmpps.manageusersapi.integration.IntegrationTestBase
@@ -31,8 +35,6 @@ import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJob
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItem
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobStatus
-import uk.gov.justice.hmpps.sqs.HmppsQueueService
-import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit.SECONDS
@@ -47,11 +49,6 @@ class BulkJobsControllerIntTest : IntegrationTestBase() {
 
   @Autowired
   private lateinit var bulkUserJobItemRepository: BulkUserJobItemRepository
-
-  @Autowired
-  protected lateinit var hmppsQueueService: HmppsQueueService
-
-  internal val itemQueue by lazy { hmppsQueueService.findByQueueId("bulkuserjobitemqueue")!! }
 
   companion object {
     @JvmStatic
@@ -134,31 +131,54 @@ class BulkJobsControllerIntTest : IntegrationTestBase() {
     @Transactional
     @Test
     open fun `bulk user additions job accepted`() {
+      listOf("USER123", "USER654").forEach { username ->
+        nomisApiMockServer.stubPostUserRoles(username, "ROLE_ONE")
+        nomisApiMockServer.stubPostUserRoles(username, "ROLE_FOUR")
+      }
+
       val response = webTestClient.post().uri("/bulk-jobs/user-role-additions")
         .headers(setAuthorisation(user = "TEST_USR", roles = listOf("ROLE_MANAGE_USER_BULK_JOBS")))
         .contentType(MediaType.MULTIPART_FORM_DATA)
         .body(buildValidMultipart())
         .exchange()
         .expectStatus().isAccepted
-        .returnResult(BulkUserRoleAdditionsResponse::class.java)
+        .returnResult<BulkUserRoleAdditionsResponse>()
         .responseBody.blockFirst()
 
       assertThat(response).isNotNull
       await.untilAsserted {
-        assertThat(itemQueue.sqsClient.countAllMessagesOnQueue(itemQueue.queueUrl).get()).isEqualTo(4)
+        val job = bulkUserJobRepository.findById(response!!.id)
+        assertThat(job).isPresent.hasValueSatisfying {
+          assertThat(it.status).isEqualTo(BulkUserJobStatus.COMPLETE)
+        }
       }
 
       val bulkJob = bulkUserJobRepository.findById(response!!.id)
       assertThat(bulkJob).isPresent.hasValueSatisfying {
-        assertThat(it).usingRecursiveComparison().ignoringFields("jobItems", "requestDateTime").isEqualTo(
-          BulkUserJob(response.id, "JIRA-1234", BulkUserJobStatus.PENDING, "TEST_USR"),
-        )
+        assertThat(it.jiraReference).isEqualTo("JIRA-1234")
+        assertThat(it.requestedBy).isEqualTo("TEST_USR")
         assertThat(it.requestDateTime).isCloseTo(LocalDateTime.now(ZoneId.systemDefault()), within(5, SECONDS))
-        assertThat(it.jobItems).usingRecursiveFieldByFieldElementComparatorIgnoringFields("id").containsExactlyInAnyOrder(
-          BulkUserJobItem(username = "USER123", rolename = "ROLE_ONE", status = BulkUserJobItemStatus.PUBLISHED, bulkUserJob = it),
-          BulkUserJobItem(username = "USER654", rolename = "ROLE_ONE", status = BulkUserJobItemStatus.PUBLISHED, bulkUserJob = it),
-          BulkUserJobItem(username = "USER123", rolename = "ROLE_FOUR", status = BulkUserJobItemStatus.PUBLISHED, bulkUserJob = it),
-          BulkUserJobItem(username = "USER654", rolename = "ROLE_FOUR", status = BulkUserJobItemStatus.PUBLISHED, bulkUserJob = it),
+        assertThat(it.jobItems)
+          .usingRecursiveFieldByFieldElementComparatorIgnoringFields("id", "status", "result", "claimedAt")
+          .containsExactlyInAnyOrder(
+            BulkUserJobItem(username = "USER123", rolename = "ROLE_ONE", bulkUserJob = it),
+            BulkUserJobItem(username = "USER654", rolename = "ROLE_ONE", bulkUserJob = it),
+            BulkUserJobItem(username = "USER123", rolename = "ROLE_FOUR", bulkUserJob = it),
+            BulkUserJobItem(username = "USER654", rolename = "ROLE_FOUR", bulkUserJob = it),
+          )
+        assertThat(it.jobItems).allSatisfy { item ->
+          assertThat(item.status).isEqualTo(BulkUserJobItemStatus.SUCCESS)
+        }
+      }
+
+      listOf("USER123", "USER654").forEach { username ->
+        nomisApiMockServer.verify(
+          postRequestedFor(urlEqualTo("/users/$username/roles?caseloadId=NWEB"))
+            .withRequestBody(containing("ROLE_ONE")),
+        )
+        nomisApiMockServer.verify(
+          postRequestedFor(urlEqualTo("/users/$username/roles?caseloadId=NWEB"))
+            .withRequestBody(containing("ROLE_FOUR")),
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/bulkjob/BulkJobsControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/resource/bulkjob/BulkJobsControllerIntTest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.manageusersapi.resource.bulkjob
 import com.github.tomakehurst.wiremock.client.WireMock.containing
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
-import jakarta.transaction.Transactional
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.within
 import org.awaitility.kotlin.await
@@ -128,7 +127,6 @@ class BulkJobsControllerIntTest : IntegrationTestBase() {
         .expectBody().jsonPath("$.userMessage").isEqualTo(expectedMessage)
     }
 
-    @Transactional
     @Test
     open fun `bulk user additions job accepted`() {
       listOf("USER123", "USER654").forEach { username ->
@@ -153,7 +151,7 @@ class BulkJobsControllerIntTest : IntegrationTestBase() {
         }
       }
 
-      val bulkJob = bulkUserJobRepository.findById(response!!.id)
+      val bulkJob = bulkUserJobRepository.findWithJobItemsById(response!!.id)
       assertThat(bulkJob).isPresent.hasValueSatisfying {
         assertThat(it.jiraReference).isEqualTo("JIRA-1234")
         assertThat(it.requestedBy).isEqualTo("TEST_USR")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/scheduled/BulkUserJobReconcilerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/scheduled/BulkUserJobReconcilerTest.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.manageusersapi.scheduled
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.BulkUserJobRepository
+import uk.gov.justice.digital.hmpps.manageusersapi.service.bulkjob.BulkUserJobReconciliationService
+import java.util.UUID
+
+class BulkUserJobReconcilerTest {
+  private val bulkUserJobRepository: BulkUserJobRepository = mock()
+  private val bulkUserJobReconciliationService: BulkUserJobReconciliationService = mock()
+  private val scheduler = BulkUserJobReconciler(bulkUserJobRepository, bulkUserJobReconciliationService)
+
+  @Test
+  fun `reconciles every incomplete job`() {
+    val jobOne = UUID.randomUUID()
+    val jobTwo = UUID.randomUUID()
+    whenever(bulkUserJobRepository.findIncompleteJobIds()).thenReturn(listOf(jobOne, jobTwo))
+
+    scheduler.reconcileIncompleteJobs()
+
+    verify(bulkUserJobReconciliationService).reconcileBulkJob(jobOne)
+    verify(bulkUserJobReconciliationService).reconcileBulkJob(jobTwo)
+  }
+
+  @Test
+  fun `does nothing when there are no incomplete jobs`() {
+    whenever(bulkUserJobRepository.findIncompleteJobIds()).thenReturn(emptyList())
+
+    scheduler.reconcileIncompleteJobs()
+
+    verify(bulkUserJobReconciliationService, never()).reconcileBulkJob(org.mockito.kotlin.any())
+  }
+
+  @Test
+  fun `continues reconciling remaining jobs when one fails`() {
+    val jobOne = UUID.randomUUID()
+    val jobTwo = UUID.randomUUID()
+    whenever(bulkUserJobRepository.findIncompleteJobIds()).thenReturn(listOf(jobOne, jobTwo))
+    whenever(bulkUserJobReconciliationService.reconcileBulkJob(jobOne)).thenThrow(RuntimeException("boom"))
+
+    scheduler.reconcileIncompleteJobs()
+
+    verify(bulkUserJobReconciliationService).reconcileBulkJob(jobTwo)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemRoleAssignmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemRoleAssignmentServiceTest.kt
@@ -1,0 +1,196 @@
+package uk.gov.justice.digital.hmpps.manageusersapi.service.bulkjob
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpHeaders
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.manageusersapi.event.BulkUserJobItemMessage
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.BulkUserJobItemRepository
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJob
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItem
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus
+import uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.UserRoleDetail
+import uk.gov.justice.digital.hmpps.manageusersapi.service.prison.UserRolesService
+import java.nio.charset.StandardCharsets
+import java.util.Optional
+
+class BulkUserJobItemRoleAssignmentServiceTest {
+  private val bulkUserJobItemRepository: BulkUserJobItemRepository = mock()
+  private val userRolesService: UserRolesService = mock()
+  private val bulkUserJobReconciliationService: BulkUserJobReconciliationService = mock()
+  private val service = BulkUserJobItemRoleAssignmentService(
+    bulkUserJobItemRepository,
+    userRolesService,
+    bulkUserJobReconciliationService,
+  )
+
+  @Test
+  fun `processes role assignment successfully`() {
+    val (message, item) = createMessageAndItem()
+    stubClaimAndLoad(item)
+    whenever(userRolesService.addRolesToUser(item.username, listOf(item.rolename), "NWEB")).thenReturn(createUserRoleDetail(item.username))
+    whenever(
+      bulkUserJobItemRepository.updateStatusAndResultIfCurrent(
+        item.id,
+        BulkUserJobItemStatus.STARTED,
+        BulkUserJobItemStatus.SUCCESS,
+        null,
+        null,
+      ),
+    ).thenReturn(1)
+
+    service.processRoleAssignmentMessage(message)
+
+    verify(userRolesService).addRolesToUser(item.username, listOf(item.rolename), "NWEB")
+    verify(bulkUserJobItemRepository).updateStatusAndResultIfCurrent(item.id, BulkUserJobItemStatus.STARTED, BulkUserJobItemStatus.SUCCESS, null, null)
+    verify(bulkUserJobReconciliationService).reconcileBulkJob(item.bulkUserJob.id)
+  }
+
+  @Test
+  fun `skips processing when item is not in published status`() {
+    val (message, item) = createMessageAndItem()
+    whenever(
+      bulkUserJobItemRepository.updateStatusIfCurrent(
+        item.id,
+        BulkUserJobItemStatus.PUBLISHED,
+        BulkUserJobItemStatus.STARTED,
+        null,
+      ),
+    ).thenReturn(0)
+
+    service.processRoleAssignmentMessage(message)
+
+    verify(bulkUserJobItemRepository, never()).findById(any())
+    verify(userRolesService, never()).addRolesToUser(any(), any(), any())
+    verify(bulkUserJobReconciliationService, never()).reconcileBulkJob(any())
+  }
+
+  @Test
+  fun `marks error when user is not found during role assignment`() {
+    val (message, item) = createMessageAndItem()
+    stubClaimAndLoad(item)
+    whenever(userRolesService.addRolesToUser(item.username, listOf(item.rolename), "NWEB")).thenThrow(notFoundException())
+    whenever(
+      bulkUserJobItemRepository.updateStatusAndResultIfCurrent(
+        item.id,
+        BulkUserJobItemStatus.STARTED,
+        BulkUserJobItemStatus.ERROR,
+        "User not found",
+        null,
+      ),
+    ).thenReturn(1)
+
+    service.processRoleAssignmentMessage(message)
+
+    verify(bulkUserJobItemRepository).updateStatusAndResultIfCurrent(item.id, BulkUserJobItemStatus.STARTED, BulkUserJobItemStatus.ERROR, "User not found", null)
+    verify(bulkUserJobReconciliationService).reconcileBulkJob(item.bulkUserJob.id)
+  }
+
+  @Test
+  fun `marks error when role is already assigned`() {
+    val (message, item) = createMessageAndItem()
+    stubClaimAndLoad(item)
+    whenever(userRolesService.addRolesToUser(item.username, listOf(item.rolename), "NWEB")).thenThrow(conflictException())
+    whenever(
+      bulkUserJobItemRepository.updateStatusAndResultIfCurrent(
+        item.id,
+        BulkUserJobItemStatus.STARTED,
+        BulkUserJobItemStatus.ERROR,
+        "Role already assigned",
+        null,
+      ),
+    ).thenReturn(1)
+
+    service.processRoleAssignmentMessage(message)
+
+    verify(bulkUserJobItemRepository).updateStatusAndResultIfCurrent(
+      item.id,
+      BulkUserJobItemStatus.STARTED,
+      BulkUserJobItemStatus.ERROR,
+      "Role already assigned",
+      null,
+    )
+    verify(bulkUserJobReconciliationService).reconcileBulkJob(item.bulkUserJob.id)
+  }
+
+  @Test
+  fun `marks system issue when assignment fails`() {
+    val (message, item) = createMessageAndItem()
+    stubClaimAndLoad(item)
+    whenever(userRolesService.addRolesToUser(item.username, listOf(item.rolename), "NWEB")).thenThrow(RuntimeException("boom"))
+    whenever(
+      bulkUserJobItemRepository.updateStatusAndResultIfCurrent(
+        item.id,
+        BulkUserJobItemStatus.STARTED,
+        BulkUserJobItemStatus.ERROR,
+        "System issue",
+        null,
+      ),
+    ).thenReturn(1)
+
+    service.processRoleAssignmentMessage(message)
+
+    verify(bulkUserJobItemRepository).updateStatusAndResultIfCurrent(
+      item.id,
+      BulkUserJobItemStatus.STARTED,
+      BulkUserJobItemStatus.ERROR,
+      "System issue",
+      null,
+    )
+    verify(bulkUserJobReconciliationService).reconcileBulkJob(item.bulkUserJob.id)
+  }
+
+  private fun stubClaimAndLoad(item: BulkUserJobItem) {
+    whenever(
+      bulkUserJobItemRepository.updateStatusIfCurrent(
+        item.id,
+        BulkUserJobItemStatus.PUBLISHED,
+        BulkUserJobItemStatus.STARTED,
+        null,
+      ),
+    ).thenReturn(1)
+    whenever(bulkUserJobItemRepository.findById(item.id)).thenReturn(Optional.of(item))
+  }
+
+  private fun createMessageAndItem(username: String = "USER123", role: String = "ROLE_ONE"): Pair<BulkUserJobItemMessage, BulkUserJobItem> {
+    val job = BulkUserJob(jiraReference = "JIRA-123", requestedBy = "userabc")
+    val item = BulkUserJobItem(username = username, rolename = role, status = BulkUserJobItemStatus.PUBLISHED, bulkUserJob = job)
+    val message = BulkUserJobItemMessage(
+      jobId = job.id,
+      jobItemId = item.id,
+      username = username,
+      rolename = role,
+      jiraReference = job.jiraReference,
+      requestedBy = job.requestedBy,
+    )
+    return message to item
+  }
+
+  private fun createUserRoleDetail(username: String) = UserRoleDetail(
+    username = username,
+    active = true,
+    activeCaseload = uk.gov.justice.digital.hmpps.manageusersapi.resource.prison.PrisonCaseload("NWEB", "Nweb", "GENERAL"),
+    dpsRoles = emptyList(),
+    nomisRoles = emptyList(),
+  )
+
+  private fun notFoundException(): WebClientResponseException = WebClientResponseException.create(
+    404,
+    "Not Found",
+    HttpHeaders.EMPTY,
+    ByteArray(0),
+    StandardCharsets.UTF_8,
+  )
+
+  private fun conflictException(): WebClientResponseException = WebClientResponseException.create(
+    409,
+    "Conflict",
+    HttpHeaders.EMPTY,
+    ByteArray(0),
+    StandardCharsets.UTF_8,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemRoleAssignmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemRoleAssignmentServiceTest.kt
@@ -51,8 +51,10 @@ class BulkUserJobItemRoleAssignmentServiceTest {
   }
 
   @Test
-  fun `skips processing when item is not in published status`() {
+  fun `skips processing when item is in a terminal status`() {
     val (message, item) = createMessageAndItem()
+    item.status = BulkUserJobItemStatus.SUCCESS
+    whenever(bulkUserJobItemRepository.findById(item.id)).thenReturn(Optional.of(item))
     whenever(
       bulkUserJobItemRepository.updateStatusIfCurrent(
         item.id,
@@ -64,9 +66,51 @@ class BulkUserJobItemRoleAssignmentServiceTest {
 
     service.processRoleAssignmentMessage(message)
 
-    verify(bulkUserJobItemRepository, never()).findById(any())
     verify(userRolesService, never()).addRolesToUser(any(), any(), any())
     verify(bulkUserJobReconciliationService, never()).reconcileBulkJob(any())
+  }
+
+  @Test
+  fun `skips processing when item no longer exists`() {
+    val (message, item) = createMessageAndItem()
+    whenever(bulkUserJobItemRepository.findById(item.id)).thenReturn(Optional.empty())
+
+    service.processRoleAssignmentMessage(message)
+
+    verify(bulkUserJobItemRepository, never()).updateStatusIfCurrent(any(), any(), any(), any())
+    verify(userRolesService, never()).addRolesToUser(any(), any(), any())
+    verify(bulkUserJobReconciliationService, never()).reconcileBulkJob(any())
+  }
+
+  @Test
+  fun `reprocesses item left started by an interrupted delivery`() {
+    val (message, item) = createMessageAndItem()
+    item.status = BulkUserJobItemStatus.STARTED
+    whenever(bulkUserJobItemRepository.findById(item.id)).thenReturn(Optional.of(item))
+    whenever(
+      bulkUserJobItemRepository.updateStatusIfCurrent(
+        item.id,
+        BulkUserJobItemStatus.PUBLISHED,
+        BulkUserJobItemStatus.STARTED,
+        null,
+      ),
+    ).thenReturn(0)
+    whenever(userRolesService.addRolesToUser(item.username, listOf(item.rolename), "NWEB")).thenReturn(createUserRoleDetail(item.username))
+    whenever(
+      bulkUserJobItemRepository.updateStatusAndResultIfCurrent(
+        item.id,
+        BulkUserJobItemStatus.STARTED,
+        BulkUserJobItemStatus.SUCCESS,
+        null,
+        null,
+      ),
+    ).thenReturn(1)
+
+    service.processRoleAssignmentMessage(message)
+
+    verify(userRolesService).addRolesToUser(item.username, listOf(item.rolename), "NWEB")
+    verify(bulkUserJobItemRepository).updateStatusAndResultIfCurrent(item.id, BulkUserJobItemStatus.STARTED, BulkUserJobItemStatus.SUCCESS, null, null)
+    verify(bulkUserJobReconciliationService).reconcileBulkJob(item.bulkUserJob.id)
   }
 
   @Test
@@ -91,7 +135,7 @@ class BulkUserJobItemRoleAssignmentServiceTest {
   }
 
   @Test
-  fun `marks error when role is already assigned`() {
+  fun `marks success when role is already assigned`() {
     val (message, item) = createMessageAndItem()
     stubClaimAndLoad(item)
     whenever(userRolesService.addRolesToUser(item.username, listOf(item.rolename), "NWEB")).thenThrow(conflictException())
@@ -99,8 +143,8 @@ class BulkUserJobItemRoleAssignmentServiceTest {
       bulkUserJobItemRepository.updateStatusAndResultIfCurrent(
         item.id,
         BulkUserJobItemStatus.STARTED,
-        BulkUserJobItemStatus.ERROR,
-        "Role already assigned",
+        BulkUserJobItemStatus.SUCCESS,
+        null,
         null,
       ),
     ).thenReturn(1)
@@ -110,8 +154,8 @@ class BulkUserJobItemRoleAssignmentServiceTest {
     verify(bulkUserJobItemRepository).updateStatusAndResultIfCurrent(
       item.id,
       BulkUserJobItemStatus.STARTED,
-      BulkUserJobItemStatus.ERROR,
-      "Role already assigned",
+      BulkUserJobItemStatus.SUCCESS,
+      null,
       null,
     )
     verify(bulkUserJobReconciliationService).reconcileBulkJob(item.bulkUserJob.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemServiceTest.kt
@@ -116,4 +116,71 @@ class BulkUserJobItemServiceTest {
       .isInstanceOf(IllegalStateException::class.java)
       .hasMessage("Bulk user job item ${item.id} could not be marked as PUBLISHED from CLAIMED")
   }
+
+  @Test
+  fun `republishes stale claimed item and marks it published`() {
+    val job = BulkUserJob(jiraReference = "JIRA-123", requestedBy = "userabc")
+    val item = BulkUserJobItem(username = "USER123", rolename = "ROLE_ONE", status = BulkUserJobItemStatus.CLAIMED, bulkUserJob = job)
+    whenever(
+      bulkUserJobItemRepository.updateStatusIfCurrent(
+        eq(item.id),
+        eq(BulkUserJobItemStatus.CLAIMED),
+        eq(BulkUserJobItemStatus.CLAIMED),
+        any(),
+      ),
+    ).thenReturn(1)
+    whenever(
+      bulkUserJobItemRepository.updateStatusIfCurrent(
+        eq(item.id),
+        eq(BulkUserJobItemStatus.CLAIMED),
+        eq(BulkUserJobItemStatus.PUBLISHED),
+        isNull(),
+      ),
+    ).thenReturn(1)
+
+    service.republishStaleClaimedItem(job, item)
+
+    verify(bulkUserJobItemPublisher).publishBulkUserJobItemEvent(job, item)
+    verify(bulkUserJobItemRepository).updateStatusIfCurrent(eq(item.id), eq(BulkUserJobItemStatus.CLAIMED), eq(BulkUserJobItemStatus.PUBLISHED), isNull())
+  }
+
+  @Test
+  fun `skips stale republish when item is no longer claimed`() {
+    val job = BulkUserJob(jiraReference = "JIRA-123", requestedBy = "userabc")
+    val item = BulkUserJobItem(username = "USER123", rolename = "ROLE_ONE", status = BulkUserJobItemStatus.PUBLISHED, bulkUserJob = job)
+    whenever(
+      bulkUserJobItemRepository.updateStatusIfCurrent(
+        eq(item.id),
+        eq(BulkUserJobItemStatus.CLAIMED),
+        eq(BulkUserJobItemStatus.CLAIMED),
+        any(),
+      ),
+    ).thenReturn(0)
+
+    service.republishStaleClaimedItem(job, item)
+
+    verify(bulkUserJobItemPublisher, never()).publishBulkUserJobItemEvent(any(), any())
+    verify(bulkUserJobItemRepository, never()).updateStatusIfCurrent(eq(item.id), eq(BulkUserJobItemStatus.CLAIMED), eq(BulkUserJobItemStatus.PUBLISHED), isNull())
+  }
+
+  @Test
+  fun `leaves stale item claimed when republish send fails`() {
+    val job = BulkUserJob(jiraReference = "JIRA-123", requestedBy = "userabc")
+    val item = BulkUserJobItem(username = "USER123", rolename = "ROLE_ONE", status = BulkUserJobItemStatus.CLAIMED, bulkUserJob = job)
+    whenever(
+      bulkUserJobItemRepository.updateStatusIfCurrent(
+        eq(item.id),
+        eq(BulkUserJobItemStatus.CLAIMED),
+        eq(BulkUserJobItemStatus.CLAIMED),
+        any(),
+      ),
+    ).thenReturn(1)
+    whenever(bulkUserJobItemPublisher.publishBulkUserJobItemEvent(job, item)).thenThrow(RuntimeException("send failed"))
+
+    assertThatThrownBy { service.republishStaleClaimedItem(job, item) }
+      .isInstanceOf(RuntimeException::class.java)
+      .hasMessage("send failed")
+
+    verify(bulkUserJobItemRepository, never()).updateStatusIfCurrent(eq(item.id), eq(BulkUserJobItemStatus.CLAIMED), eq(BulkUserJobItemStatus.PUBLISHED), isNull())
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobItemServiceTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.manageusersapi.repository.BulkUserJobItemRep
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJob
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItem
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus
+import java.time.Instant
 import java.util.UUID
 
 class BulkUserJobItemServiceTest {
@@ -164,9 +165,11 @@ class BulkUserJobItemServiceTest {
   }
 
   @Test
-  fun `leaves stale item claimed when republish send fails`() {
+  fun `leaves stale item claimed and restores original claimedAt when republish send fails`() {
     val job = BulkUserJob(jiraReference = "JIRA-123", requestedBy = "userabc")
+    val originalClaimedAt = Instant.now().minusSeconds(7200)
     val item = BulkUserJobItem(username = "USER123", rolename = "ROLE_ONE", status = BulkUserJobItemStatus.CLAIMED, bulkUserJob = job)
+    item.claimedAt = originalClaimedAt
     whenever(
       bulkUserJobItemRepository.updateStatusIfCurrent(
         eq(item.id),
@@ -181,6 +184,12 @@ class BulkUserJobItemServiceTest {
       .isInstanceOf(RuntimeException::class.java)
       .hasMessage("send failed")
 
+    verify(bulkUserJobItemRepository).updateStatusIfCurrent(
+      eq(item.id),
+      eq(BulkUserJobItemStatus.CLAIMED),
+      eq(BulkUserJobItemStatus.CLAIMED),
+      eq(originalClaimedAt),
+    )
     verify(bulkUserJobItemRepository, never()).updateStatusIfCurrent(eq(item.id), eq(BulkUserJobItemStatus.CLAIMED), eq(BulkUserJobItemStatus.PUBLISHED), isNull())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobReconciliationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobReconciliationServiceTest.kt
@@ -1,0 +1,99 @@
+package uk.gov.justice.digital.hmpps.manageusersapi.service.bulkjob
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.BulkUserJobItemRepository
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.BulkUserJobRepository
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJob
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItem
+import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus
+import java.time.Duration
+import java.time.Instant
+import java.util.Optional
+
+class BulkUserJobReconciliationServiceTest {
+  private val bulkUserJobItemRepository: BulkUserJobItemRepository = mock()
+  private val bulkUserJobRepository: BulkUserJobRepository = mock()
+  private val bulkUserJobItemService: BulkUserJobItemService = mock()
+  private val service = BulkUserJobReconciliationService(
+    bulkUserJobItemRepository,
+    bulkUserJobRepository,
+    bulkUserJobItemService,
+    Duration.ofHours(1),
+  )
+
+  @Test
+  fun `marks job complete when no stale claimed items`() {
+    val job = BulkUserJob(jiraReference = "JIRA-1", requestedBy = "userabc")
+    whenever(
+      bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndClaimedAtBefore(
+        eq(job.id),
+        eq(BulkUserJobItemStatus.CLAIMED),
+        any(),
+      ),
+    ).thenReturn(emptyList())
+    whenever(bulkUserJobRepository.markCompleteIfAllItemsTerminal(job.id)).thenReturn(1)
+
+    service.reconcileBulkJob(job.id)
+
+    verify(bulkUserJobRepository).markCompleteIfAllItemsTerminal(job.id)
+    verify(bulkUserJobItemService, never()).republishStaleClaimedItem(any(), any())
+  }
+
+  @Test
+  fun `republishes stale claimed items then attempts completion`() {
+    val job = BulkUserJob(jiraReference = "JIRA-1", requestedBy = "userabc")
+    val staleItem = BulkUserJobItem(
+      username = "USER999",
+      rolename = "ROLE_STALE",
+      status = BulkUserJobItemStatus.CLAIMED,
+      claimedAt = Instant.now().minus(Duration.ofHours(2)),
+      bulkUserJob = job,
+    )
+    whenever(
+      bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndClaimedAtBefore(
+        eq(job.id),
+        eq(BulkUserJobItemStatus.CLAIMED),
+        any(),
+      ),
+    ).thenReturn(listOf(staleItem))
+    whenever(bulkUserJobRepository.findWithJobItemsById(job.id)).thenReturn(Optional.of(job))
+    whenever(bulkUserJobRepository.markCompleteIfAllItemsTerminal(job.id)).thenReturn(0)
+
+    service.reconcileBulkJob(job.id)
+
+    verify(bulkUserJobItemService).republishStaleClaimedItem(job, staleItem)
+    verify(bulkUserJobRepository).markCompleteIfAllItemsTerminal(job.id)
+  }
+
+  @Test
+  fun `continues reconciliation when a stale republish fails`() {
+    val job = BulkUserJob(jiraReference = "JIRA-1", requestedBy = "userabc")
+    val staleItem = BulkUserJobItem(
+      username = "USER999",
+      rolename = "ROLE_STALE",
+      status = BulkUserJobItemStatus.CLAIMED,
+      claimedAt = Instant.now().minus(Duration.ofHours(2)),
+      bulkUserJob = job,
+    )
+    whenever(
+      bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndClaimedAtBefore(
+        eq(job.id),
+        eq(BulkUserJobItemStatus.CLAIMED),
+        any(),
+      ),
+    ).thenReturn(listOf(staleItem))
+    whenever(bulkUserJobRepository.findWithJobItemsById(job.id)).thenReturn(Optional.of(job))
+    whenever(bulkUserJobItemService.republishStaleClaimedItem(job, staleItem)).thenThrow(RuntimeException("publish failed"))
+    whenever(bulkUserJobRepository.markCompleteIfAllItemsTerminal(job.id)).thenReturn(0)
+
+    service.reconcileBulkJob(job.id)
+
+    verify(bulkUserJobRepository).markCompleteIfAllItemsTerminal(job.id)
+  }
+}


### PR DESCRIPTION
- Listener for bulk user role job items to process an individual role assignment, 1 role for 1 user
- Records information on success or error in db
- Reconcile overall job after the role assignment to mark as complete or republish any stale job items
- Scheduled task to routinely reconcile bulk jobs in case the final reconcile step fails for any reason