### PR TITLE
HAAR-5581: Fix issues with bulk user job processing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/repository/BulkUserJobItemRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/repository/BulkUserJobItemRepository.kt
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItem
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus
 import java.time.Instant
+import java.time.LocalDateTime
 import java.util.UUID
 import java.util.stream.Stream
 
@@ -17,6 +18,20 @@ interface BulkUserJobItemRepository : JpaRepository<BulkUserJobItem, UUID> {
 
   fun streamByBulkUserJobId(jobId: UUID): Stream<BulkUserJobItem>
   fun findByBulkUserJobIdAndStatusAndClaimedAtBefore(jobId: UUID, status: BulkUserJobItemStatus, claimedAt: Instant): List<BulkUserJobItem>
+
+  @Query(
+    """
+      SELECT i FROM BulkUserJobItem i
+      WHERE i.bulkUserJob.id = :jobId
+        AND i.status = :status
+        AND i.bulkUserJob.requestDateTime < :requestedBefore
+    """,
+  )
+  fun findByBulkUserJobIdAndStatusAndJobRequestedBefore(
+    @Param("jobId") jobId: UUID,
+    @Param("status") status: BulkUserJobItemStatus,
+    @Param("requestedBefore") requestedBefore: LocalDateTime,
+  ): List<BulkUserJobItem>
 
   @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobReconciliationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobReconciliationService.kt
@@ -8,6 +8,8 @@ import uk.gov.justice.digital.hmpps.manageusersapi.repository.BulkUserJobReposit
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.model.BulkUserJobItemStatus
 import java.time.Duration
 import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
 import java.util.UUID
 
 @Service
@@ -23,6 +25,7 @@ class BulkUserJobReconciliationService(
 
   fun reconcileBulkJob(jobId: UUID) {
     republishStaleClaimedItems(jobId)
+    republishUnprocessedCreatedItems(jobId)
     val updatedRows = bulkUserJobRepository.markCompleteIfAllItemsTerminal(jobId)
     if (updatedRows == 1) {
       log.info("Marked bulk user job {} as COMPLETE", jobId)
@@ -49,6 +52,32 @@ class BulkUserJobReconciliationService(
         log.error(
           "Failed to re-publish stale claimed bulk user job item {}; it remains CLAIMED and will be retried",
           staleItem.id,
+          e,
+        )
+      }
+    }
+  }
+
+  private fun republishUnprocessedCreatedItems(jobId: UUID) {
+    val staleCreatedCutoff = LocalDateTime.now(ZoneId.systemDefault()).minus(staleClaimedThreshold)
+    val createdItems = bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndJobRequestedBefore(
+      jobId = jobId,
+      status = BulkUserJobItemStatus.CREATED,
+      requestedBefore = staleCreatedCutoff,
+    )
+    if (createdItems.isEmpty()) return
+
+    val job = bulkUserJobRepository.findWithJobItemsById(jobId)
+      .orElseThrow { IllegalStateException("Bulk user job $jobId not found when processing unprocessed created items") }
+
+    createdItems.forEach { createdItem ->
+      try {
+        log.warn("Processing unpublished (CREATED) bulk user job item {} for job {}", createdItem.id, jobId)
+        bulkUserJobItemService.processJobItem(job, createdItem)
+      } catch (e: Exception) {
+        log.error(
+          "Failed to process unpublished bulk user job item {}; it remains CREATED and will be retried",
+          createdItem.id,
           e,
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.manageusersapi.service.bulkjob
 import jakarta.validation.ValidationException
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVRecord
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
@@ -31,6 +32,7 @@ class BulkUserJobService(
 ) {
   companion object {
     private const val USER_ID_HEADER = "userId"
+    private val log = LoggerFactory.getLogger(this::class.java)
   }
 
   @Transactional
@@ -51,7 +53,13 @@ class BulkUserJobService(
       TransactionSynchronizationManager.registerSynchronization(
         object : TransactionSynchronization {
           override fun afterCommit() {
-            bulkJobPublisher.publishBulkUserJobEvent(bulkJob)
+            try {
+              bulkJobPublisher.publishBulkUserJobEvent(bulkJob)
+            } catch (e: Exception) {
+              // The job and its items are already persisted at this point, so do not expose this error to the caller
+              // so they still receives the job id - the scheduled reconciler will republish the unprocessed CREATED items.
+              log.error("Failed to publish bulk user job event for job {} after commit - leaving for reconciliation", bulkJob.id, e)
+            }
           }
         },
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobService.kt
@@ -9,6 +9,8 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.web.multipart.MultipartFile
 import uk.gov.justice.digital.hmpps.manageusersapi.event.BulkJobPublisher
 import uk.gov.justice.digital.hmpps.manageusersapi.repository.BulkUserJobItemRepository
@@ -39,8 +41,23 @@ class BulkUserJobService(
   ): UUID {
     val users = parseFileForUsers(usersCsv)
     val bulkJob = createAndPersistJob(bulkJobDetails, requestedBy, users)
-    bulkJobPublisher.publishBulkUserJobEvent(bulkJob)
+    publishAfterCommit(bulkJob)
     return bulkJob.id
+  }
+
+  private fun publishAfterCommit(bulkJob: BulkUserJob) {
+    // Ensure publish only happens if the job has been persisted so we do not try to process before that has happened
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(
+        object : TransactionSynchronization {
+          override fun afterCommit() {
+            bulkJobPublisher.publishBulkUserJobEvent(bulkJob)
+          }
+        },
+      )
+    } else {
+      bulkJobPublisher.publishBulkUserJobEvent(bulkJob)
+    }
   }
 
   fun getBulkUserRoleAdditionsJobs(search: String, pageNumber: Int?, pageSize: Int?): List<BulkUserJob> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/repository/BulkUserJobItemRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/repository/BulkUserJobItemRepositoryTest.kt
@@ -262,6 +262,90 @@ class BulkUserJobItemRepositoryTest(
     }
   }
 
+  @Nested
+  inner class FindByBulkUserJobIdAndStatusAndJobRequestedBefore {
+    private val cutoff: LocalDateTime = LocalDateTime.parse("2026-08-11T10:00:00")
+
+    @Test
+    fun `returns created items for jobs requested before the cutoff`() {
+      val job = BulkUserJob(
+        id = UUID.fromString("44444444-4444-4444-4444-444444444444"),
+        status = PENDING,
+        jiraReference = "ABC-123",
+        requestedBy = "Test",
+        requestDateTime = cutoff.minusMinutes(1),
+      )
+      val createdItem = createJobItemWithStatus(job, 1, CREATED)
+      job.jobItems.add(createdItem)
+      bulkUserJobRepository.saveAndFlush(job)
+
+      val actual = bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndJobRequestedBefore(job.id, CREATED, cutoff)
+
+      assertThat(actual).containsExactly(createdItem)
+    }
+
+    @Test
+    fun `excludes items for jobs requested at or after the cutoff`() {
+      val job = BulkUserJob(
+        id = UUID.fromString("55555555-5555-5555-5555-555555555555"),
+        status = PENDING,
+        jiraReference = "ABC-123",
+        requestedBy = "Test",
+        requestDateTime = cutoff,
+      )
+      job.jobItems.add(createJobItemWithStatus(job, 1, CREATED))
+      bulkUserJobRepository.saveAndFlush(job)
+
+      val actual = bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndJobRequestedBefore(job.id, CREATED, cutoff)
+
+      assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `excludes items with a different status`() {
+      val job = BulkUserJob(
+        id = UUID.fromString("66666666-6666-6666-6666-666666666666"),
+        status = PENDING,
+        jiraReference = "ABC-123",
+        requestedBy = "Test",
+        requestDateTime = cutoff.minusMinutes(1),
+      )
+      job.jobItems.add(createJobItemWithStatus(job, 1, PUBLISHED))
+      bulkUserJobRepository.saveAndFlush(job)
+
+      val actual = bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndJobRequestedBefore(job.id, CREATED, cutoff)
+
+      assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `excludes created items belonging to a different job`() {
+      val job = BulkUserJob(
+        id = UUID.fromString("77777777-7777-7777-7777-777777777777"),
+        status = PENDING,
+        jiraReference = "ABC-123",
+        requestedBy = "Test",
+        requestDateTime = cutoff.minusMinutes(1),
+      )
+      val otherJob = BulkUserJob(
+        id = UUID.fromString("88888888-8888-8888-8888-888888888888"),
+        status = PENDING,
+        jiraReference = "DEF-456",
+        requestedBy = "Test",
+        requestDateTime = cutoff.minusMinutes(1),
+      )
+      job.jobItems.add(createJobItemWithStatus(job, 1, CREATED))
+      otherJob.jobItems.add(createJobItemWithStatus(otherJob, 2, CREATED))
+      bulkUserJobRepository.saveAndFlush(job)
+      bulkUserJobRepository.saveAndFlush(otherJob)
+
+      val actual = bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndJobRequestedBefore(job.id, CREATED, cutoff)
+
+      assertThat(actual).hasSize(1)
+      assertThat(actual.first().bulkUserJob.id).isEqualTo(job.id)
+    }
+  }
+
   private fun createBulkUserJobWithStatus(status: BulkUserJobStatus) = BulkUserJob(
     id = UUID.fromString("33333333-3333-3333-3333-333333333333"),
     status = status,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobReconciliationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobReconciliationServiceTest.kt
@@ -96,4 +96,68 @@ class BulkUserJobReconciliationServiceTest {
 
     verify(bulkUserJobRepository).markCompleteIfAllItemsTerminal(job.id)
   }
+
+  @Test
+  fun `processes unprocessed created items for stale jobs then attempts completion`() {
+    val job = BulkUserJob(jiraReference = "JIRA-1", requestedBy = "userabc")
+    val createdItem = BulkUserJobItem(
+      username = "USER111",
+      rolename = "ROLE_NEW",
+      status = BulkUserJobItemStatus.CREATED,
+      bulkUserJob = job,
+    )
+    whenever(
+      bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndClaimedAtBefore(
+        eq(job.id),
+        eq(BulkUserJobItemStatus.CLAIMED),
+        any(),
+      ),
+    ).thenReturn(emptyList())
+    whenever(
+      bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndJobRequestedBefore(
+        eq(job.id),
+        eq(BulkUserJobItemStatus.CREATED),
+        any(),
+      ),
+    ).thenReturn(listOf(createdItem))
+    whenever(bulkUserJobRepository.findWithJobItemsById(job.id)).thenReturn(Optional.of(job))
+    whenever(bulkUserJobRepository.markCompleteIfAllItemsTerminal(job.id)).thenReturn(0)
+
+    service.reconcileBulkJob(job.id)
+
+    verify(bulkUserJobItemService).processJobItem(job, createdItem)
+    verify(bulkUserJobRepository).markCompleteIfAllItemsTerminal(job.id)
+  }
+
+  @Test
+  fun `continues reconciliation when a created item republish fails`() {
+    val job = BulkUserJob(jiraReference = "JIRA-1", requestedBy = "userabc")
+    val createdItem = BulkUserJobItem(
+      username = "USER111",
+      rolename = "ROLE_NEW",
+      status = BulkUserJobItemStatus.CREATED,
+      bulkUserJob = job,
+    )
+    whenever(
+      bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndClaimedAtBefore(
+        eq(job.id),
+        eq(BulkUserJobItemStatus.CLAIMED),
+        any(),
+      ),
+    ).thenReturn(emptyList())
+    whenever(
+      bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndJobRequestedBefore(
+        eq(job.id),
+        eq(BulkUserJobItemStatus.CREATED),
+        any(),
+      ),
+    ).thenReturn(listOf(createdItem))
+    whenever(bulkUserJobRepository.findWithJobItemsById(job.id)).thenReturn(Optional.of(job))
+    whenever(bulkUserJobItemService.processJobItem(job, createdItem)).thenThrow(RuntimeException("publish failed"))
+    whenever(bulkUserJobRepository.markCompleteIfAllItemsTerminal(job.id)).thenReturn(0)
+
+    service.reconcileBulkJob(job.id)
+
+    verify(bulkUserJobRepository).markCompleteIfAllItemsTerminal(job.id)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobReconciliationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageusersapi/service/bulkjob/BulkUserJobReconciliationServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.manageusersapi.service.bulkjob
 
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -26,6 +27,17 @@ class BulkUserJobReconciliationServiceTest {
     bulkUserJobItemService,
     Duration.ofHours(1),
   )
+
+  @BeforeEach
+  fun defaultStubs() {
+    whenever(
+      bulkUserJobItemRepository.findByBulkUserJobIdAndStatusAndJobRequestedBefore(
+        any(),
+        any(),
+        any(),
+      ),
+    ).thenReturn(emptyList())
+  }
 
   @Test
   fun `marks job complete when no stale claimed items`() {


### PR DESCRIPTION
- Ensures bulk job is persisted before publishing message to prevent issues with items not being found
- Reconcile jobs where items are stuck in CREATED but never had a message published